### PR TITLE
OC-20: Add support for type use annotations in field declaration generics

### DIFF
--- a/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
+++ b/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
@@ -851,8 +851,10 @@ typeArguments
 
 singleTypeArgument {
   String type = null;
+  AnnotationImpl ann = null;
 }
     :
+        ( ann=annotation )*
         (
             type=classTypeSpec | type=builtInTypeSpec | QUESTION
         )

--- a/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax18CompilationTest.groovy
+++ b/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax18CompilationTest.groovy
@@ -474,4 +474,12 @@ class JavaSyntax18CompilationTest extends JavaSyntaxCompilationTestBase {
             instrumentAndCompileSourceFile(srcDir, mGenSrcDir, "pck/package-info.java", JavaEnvUtils.JAVA_1_8)
         }
     }
+
+    void testTypeAnnotationInFieldDeclarationGeneric() {
+        if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_8)) {
+            final String fileName = "typeannotation/fielddeclarationgenerics/TypeAnnotationInFieldDeclarationGenerics.java"
+            instrumentAndCompileSourceFile(srcDir, mGenSrcDir, fileName, JavaEnvUtils.JAVA_1_8)
+            assertFileMatches(fileName, R_INC + "System.out.println", false)
+        }
+    }
 }

--- a/clover-core/src/test/resources/javasyntax1.8/typeannotation/fielddeclarationgenerics/TypeAnnotationInFieldDeclarationGenerics.java
+++ b/clover-core/src/test/resources/javasyntax1.8/typeannotation/fielddeclarationgenerics/TypeAnnotationInFieldDeclarationGenerics.java
@@ -1,0 +1,24 @@
+package typeannotation.fielddeclarationgenerics;
+
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+
+public class TypeAnnotationInFieldDeclarationGenerics {
+    private final HashMap<@AnnotationForType1 String, String> map = new HashMap<>();
+
+    public static void main(String args[]) {
+        TypeAnnotationInFieldDeclarationGenerics j = new TypeAnnotationInFieldDeclarationGenerics();
+        j.getSize();
+    }
+    public void getSize() {
+        System.out.println(map.size());
+    }
+}
+
+@Retention(RUNTIME) @Target({ElementType.TYPE_USE})
+@interface AnnotationForType1 {
+}


### PR DESCRIPTION
Closes #20, closed #93
- Add support for type use annotations in field declaration generics