### PR TITLE
OC-59: Add support for primitive type array constructor reference

### DIFF
--- a/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
+++ b/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
@@ -2480,10 +2480,14 @@ primaryExpressionPart
             {
                 pushIdentifierToHeadStack(LT(0).getText());
             }
-        // look for int.class and int[].class
+        // look for int.class, int[].class, and int[]::new
     |   type=builtInType
         ( LBRACK  RBRACK! )*
-        DOT "class"
+        (
+            DOT "class"
+        |
+            METHOD_REF "new"
+        )
     ;
 
 /**

--- a/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax18CompilationTest.groovy
+++ b/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax18CompilationTest.groovy
@@ -474,4 +474,11 @@ class JavaSyntax18CompilationTest extends JavaSyntaxCompilationTestBase {
             instrumentAndCompileSourceFile(srcDir, mGenSrcDir, "pck/package-info.java", JavaEnvUtils.JAVA_1_8)
         }
     }
+
+    void testPrimitiveArrayConstructorReference() {
+        if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_8)) {
+            final String fileName = "java8/Java8ArrayConstructorReference.java"
+            instrumentAndCompileSourceFile(srcDir, mGenSrcDir, fileName, JavaEnvUtils.JAVA_1_8)
+        }
+    }
 }

--- a/clover-core/src/test/resources/javasyntax1.8/java8/Java8ArrayConstructorReference.java
+++ b/clover-core/src/test/resources/javasyntax1.8/java8/Java8ArrayConstructorReference.java
@@ -1,0 +1,11 @@
+package java8;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class Java8ArrayConstructorReference {
+    public static byte[][] toPayloads(String... strings) {
+        return Arrays.stream(strings).map(s -> s == null ? null : s.getBytes(StandardCharsets.UTF_8))
+                .toArray(byte[][]::new);
+    }
+}


### PR DESCRIPTION
Closes #59, Closes #95
- Add support for primitive type array constructor reference