### PR TITLE
Add support for type use annotations in array field declaration

### DIFF
--- a/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
+++ b/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
@@ -1528,8 +1528,13 @@ variableDeclarator!
 declaratorBrackets returns [String brackets]
 {
     brackets = "";
+    AnnotationImpl ann = null;
 }
-    :   (LBRACK RBRACK! {brackets += "[]";})*
+    :
+        (
+            (ann=annotation)*
+            LBRACK RBRACK! {brackets += "[]";}
+        )*
     ;
 
 varInitializer

--- a/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax18CompilationTest.groovy
+++ b/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax18CompilationTest.groovy
@@ -474,4 +474,11 @@ class JavaSyntax18CompilationTest extends JavaSyntaxCompilationTestBase {
             instrumentAndCompileSourceFile(srcDir, mGenSrcDir, "pck/package-info.java", JavaEnvUtils.JAVA_1_8)
         }
     }
+
+    void testTypeAnnotationInFieldDeclarationPostposingArray() {
+        if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_8)) {
+            final String fileName = "typeannotation/fielddeclarationpostposingarray/TypeAnnotationInFieldDeclarationPostposingArray.java"
+            instrumentAndCompileSourceFile(srcDir, mGenSrcDir, fileName, JavaEnvUtils.JAVA_1_8)
+        }
+    }
 }

--- a/clover-core/src/test/resources/javasyntax1.8/typeannotation/fielddeclarationpostposingarray/TypeAnnotationInFieldDeclarationPostposingArray.java
+++ b/clover-core/src/test/resources/javasyntax1.8/typeannotation/fielddeclarationpostposingarray/TypeAnnotationInFieldDeclarationPostposingArray.java
@@ -1,0 +1,15 @@
+package typeannotation.fielddeclarationpostposingarray;
+
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+public class TypeAnnotationInFieldDeclarationPostposingArray {
+    private int intArray @AnnotationForType1 [][] = new int[2][2];
+}
+
+@Retention(RUNTIME) @Target({ElementType.TYPE_USE})
+@interface AnnotationForType1 {
+}


### PR DESCRIPTION
Closes #157.
- Add support for type use annotations in array field declaration
