### PR TITLE
Fix #165. Upgrade log4j version to 2.17.2

### DIFF
--- a/clover-core-libs/versions.xml
+++ b/clover-core-libs/versions.xml
@@ -14,6 +14,6 @@
     <property name="jcommon.ver" value="1.0.23"/>
     <property name="jdom.ver" value="1.0"/>
     <property name="jfreechart.ver" value="1.0.19"/>
-    <property name="log4j.ver" value="1.2.17"/>
+    <property name="log4j.ver" value="2.17.2"/>
     <property name="velocity.ver" value="1.7"/>
 </project>


### PR DESCRIPTION
Fix #165. Upgrade log4j version to 2.17.2 to avoid Vulnerabilities from dependencies:

[CVE-2022-23305](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23305)
[CVE-2022-23302](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23302)
[CVE-2022-23221](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23221)
[CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550)
[CVE-2021-4104](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104)
[CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)
