### PR TITLE
OC-177: Simplify initial project configuration for development

### DIFF
--- a/.github/workflows/A-test-master.yml
+++ b/.github/workflows/A-test-master.yml
@@ -12,25 +12,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    
-#    - name: Download KTreemap fork
-#      run: |
-#         git clone https://bitbucket.org/atlassian/ktreemap
-#         cd ktreemap
-#         git checkout ktreemap-1.1.0-atlassian-01
-#         mvn install   # fails because of missing eclipse artifact
+      - uses: actions/checkout@v2
 
-    - name: Prepare repacked third party libraries
-      run: |
-        mvn install -f clover-core-libs/jarjar/pom.xml
-        mvn install -Prepack -f clover-core-libs/pom.xml
-        mvn install -Prepack -f clover-idea/clover-jtreemap/pom.xml
- 
-    - name: Run core tests
-      run: ant -noinput -buildfile build.xml clover-core.test clover-ant.test groovy.test
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Prepare repacked third party libraries
+        run: |
+          mvn install -f clover-core-libs/jarjar/pom.xml
+          mvn install -Prepack -f clover-core-libs/pom.xml
+          mvn install -Prepack -f clover-idea/clover-jtreemap/pom.xml
+
+      - name: Download Eclipse IDE binaries
+        run: ant -noinput -buildfile build.xml clover-eclipse-libs.build
+
+      - name: Download KTreemap fork
+        run: |
+           git clone https://bitbucket.org/atlassian/ktreemap
+           cd ktreemap
+           git checkout ktreemap-1.1.0-atlassian-01           
+           # an old maven-antrun-plugin does not recognize <target> tag
+           sed -i 's/<artifactId>maven-antrun-plugin</artifactId>/<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>' pom.xml
+           # maven dependency plugin fails because of missing eclipse artifact so copy it manually
+           mkdir target/eclipse
+           cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse           
+           mvn install -Dmdep.skip=true  
+           cd ..
+
+      - name: Run core tests
+        run: |
+           ant -noinput -buildfile build.xml clover-core.test clover-ant.test groovy.test
+           ant -noinput -buildfile build.xml clover-eclipse.build.all.versions
+        

--- a/README.md
+++ b/README.md
@@ -54,32 +54,44 @@ See also:
 * Prepare work environment: 
 
 ```
-#  Download KTreemap fork
-#  git clone https://bitbucket.org/atlassian/ktreemap
-#  cd ktreemap
-#  git checkout ktreemap-1.1.0-atlassian-01
-#  mvn install   # fails because of missing eclipse artifact
-
 # Prepare repacked third party libraries
 mvn install -f clover-core-libs/jarjar/pom.xml
 mvn install -Prepack -f clover-core-libs/pom.xml
 mvn install -Prepack -f clover-idea/clover-jtreemap/pom.xml
+
+# Download Eclipse IDE binaries
+ant clover-eclipse-libs.build
+
+# Download KTremap fork and install it
+git clone https://bitbucket.org/atlassian/ktreemap
+cd ktreemap
+git checkout ktreemap-1.1.0-atlassian-01
+# an old maven-antrun-plugin does not recognize <target> tag
+sed -i 's/<artifactId>maven-antrun-plugin</artifactId>/<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>' pom.xml
+# maven-dependency-plugin fails because of missing eclipse artifact so copy JARs manually
+mkdir target/eclipse; cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse
+mvn install -Dmdep.skip=true  
+cd ..
 ```
 
 Now you can work with the code. A naming convention for Ant targets is:
 
-<global | module-name>.<build | test.build | test | clean | repkg>
+< global | module-name >.< build | test.build | test | clean | repkg >
 
-There are more global and module-specific targets available.
+There are more global and module-specific targets available, see build.xml files.
 
 Examples:
 
 ```
 # Compile everything, including tests
-ant global.test.build 
-```
+ant global.test.build
 
-```
+# Check binary compatibility wtih all Eclipse versions supported 
+ant clover-eclipse.build.all.versions
+
+# Check binary compatibility wtih all IntelliJ versions supported
+ant clover-idea.test.all.versions
+
 # Run tests for three main modules
 ant clover-core.test clover-ant.test groovy.test
 ```

--- a/build.properties
+++ b/build.properties
@@ -65,13 +65,11 @@ idea16.home=${build.deps.dir}/idea/2016.2.162112132
 # Path to Eclipse installation directories. You need at least Eclipse 4.2 to compile Clover plugin.
 # You can install other versions to run compatiblity tests. Example paths:
 #
-# eclipse-4.5.1.home=/Applications/Eclipse-Mars.app/Contents/Eclipse/configuration
-# eclipse-4.5.1.home=c:\\Eclipse\\eclipse-mars
+# eclipse-4.5.home=/Applications/Eclipse-Mars.app/Contents/Eclipse/configuration
+# eclipse-4.5.home=c:\\Eclipse\\eclipse-mars
 #
 # Hint: you can create a Maven artifact, see clover-eclipse/clover-eclipse-libs/pom.xml
 #
-eclipse-4.2.2.home=${build.deps.dir}/eclipse/4.2.2
-eclipse-4.3.1.home=${build.deps.dir}/eclipse/4.3.1
-eclipse-4.4.0.home=${build.deps.dir}/eclipse/4.4.0
-eclipse-4.5.1.home=${build.deps.dir}/eclipse/4.5.1
-eclipse-4.6.0.home=${build.deps.dir}/eclipse/4.6.0
+eclipse-4.4.home=${build.deps.dir}/eclipse/4.4
+eclipse-4.5.home=${build.deps.dir}/eclipse/4.5
+eclipse-4.6.home=${build.deps.dir}/eclipse/4.6

--- a/clover-eclipse/build.xml
+++ b/clover-eclipse/build.xml
@@ -119,15 +119,13 @@
     </macrodef>
 
     <target name="clover-eclipse.build" depends="clover-core.build, clover-eclipse-libs.initialize">
-        <build-plugin eclipse-version="4.2.2"/>
+        <build-plugin eclipse-version="4.4"/>
     </target>
 
     <target name="clover-eclipse.build.all.versions" depends="clover-core.build, clover-eclipse-libs.initialize">
-        <build-plugin eclipse-version="4.2.2"/>
-        <build-plugin eclipse-version="4.3.1"/>
-        <build-plugin eclipse-version="4.4.0"/>
-        <build-plugin eclipse-version="4.5.1"/>
-        <build-plugin eclipse-version="4.6.0"/>
+        <build-plugin eclipse-version="4.4"/>
+        <build-plugin eclipse-version="4.5"/>
+        <build-plugin eclipse-version="4.6"/>
     </target>
 
     <!-- The dependency on clover-ant.pkg is required here. We need the clover ant

--- a/clover-eclipse/clover-eclipse-libs/build.xml
+++ b/clover-eclipse/clover-eclipse-libs/build.xml
@@ -1,35 +1,73 @@
 <project name="clover-eclipse-libs" basedir="." default="clover-eclipse-libs.build">
     <import file="../../common.xml"/>
 
-    <macrodef name="download-eclipse">
-        <attribute name="version"/>
+    <macrodef name="download-eclipse-from-maven">
+        <attribute name="version"/>      <!-- how we will version it locally -->
+        <attribute name="mavenVersion"/> <!-- what version has source artifact in maven -->
         <sequential>
             <if>
                 <not>
                     <available file="${build.deps.dir}/eclipse/@{version}"/>
                 </not>
                 <then>
-                    <echo message="Downloading clover-eclipse-libs-@{version}-bin.zip ..."/>
-                    <maven-resolve groupId="com.atlassian.clover" artifactId="clover-eclipse-libs" version="@{version}"
+                    <echo message="Downloading clover-eclipse-libs-@{mavenVersion}-bin.zip from Maven ..."/>
+                    <maven-resolve groupId="com.atlassian.clover" artifactId="clover-eclipse-libs" version="@{mavenVersion}"
                                     classifier="bin" packaging="zip"/>
                     <!-- Trick: dependency task creates property named as full artifact qualifier (but without version
                          number) containing full path to a file -->
                     <echo message="Unpacking ${com.atlassian.clover:clover-eclipse-libs:zip:bin} to ${build.deps.dir}/eclipse/@{version}/plugins ..."/>
                     <unzip src="${com.atlassian.clover:clover-eclipse-libs:zip:bin}"
                            dest="${build.deps.dir}/eclipse/@{version}/plugins"/>
+                    <echo message=""/>
                 </then>
             </if>
         </sequential>
     </macrodef>
 
+    <macrodef name="download-eclipse-from-website">
+        <attribute name="version"/>
+        <attribute name="path"/>
+        <attribute name="file"/>
+        <sequential>
+            <property name="eclipse.download.url"
+                      value="https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release"/>
+            <if>
+                <not>
+                    <available file="${build.deps.dir}/eclipse/@{file}"/>
+                </not>
+                <then>
+                    <echo message="Downloading @{file} from website ..."/>
+                    <mkdir dir="${build.deps.dir}/eclipse"/>
+                    <get src="${eclipse.download.url}/@{path}/@{file}"
+                         dest="${build.deps.dir}/eclipse/@{file}"/>
+
+                    <echo message="Unpacking @{file} to ${build.deps.dir}/eclipse/@{version} ..."/>
+                    <unzip src="${build.deps.dir}/eclipse/@{file}"
+                           dest="${build.deps.dir}/eclipse/@{version}">
+                        <!-- strip "eclipse" from the unpacked path -->
+                        <mapper type="regexp" from="^eclipse/(.*)" to="\1"/>
+                    </unzip>
+                    <echo message=""/>
+                </then>
+            </if>
+        </sequential>
+
+    </macrodef>
+
     <target name="clover-eclipse-libs.clean"/>
 
-    <target name="-eclipse.download" if="download.internal.maven.artifacts">
-        <download-eclipse version="4.2.2"/>
-        <download-eclipse version="4.3.1"/>
-        <download-eclipse version="4.4.0"/>
-        <download-eclipse version="4.5.1"/>
-        <download-eclipse version="4.6.0"/>
+    <target name="-eclipse.download" depends="-eclipse.download.maven, -eclipse.download.website"/>
+
+    <target name="-eclipse.download.maven" if="download.internal.maven.artifacts">
+        <download-eclipse-from-maven version="4.4" mavenVersion="4.4.0"/>
+        <download-eclipse-from-maven version="4.5" mavenVersion="4.5.1"/>
+        <download-eclipse-from-maven version="4.6" mavenVersion="4.6.0"/>
+    </target>
+
+    <target name="-eclipse.download.website" unless="download.internal.maven.artifacts">
+        <download-eclipse-from-website version="4.4" path="luna/SR2" file="eclipse-java-luna-SR2-win32-x86_64.zip"/>
+        <download-eclipse-from-website version="4.5" path="mars/2" file="eclipse-jee-mars-2-win32-x86_64.zip"/>
+        <download-eclipse-from-website version="4.6" path="neon/3" file="eclipse-java-neon-3-win32-x86_64.zip"/>
     </target>
 
     <target name="clover-eclipse-libs.initialize" depends="-eclipse.download"/>


### PR DESCRIPTION
Simplify Eclipse setup, download binaries from the website if they're not stored as Maven artifacts; also drop Eclipse 4.2 and 4.3 in build files; enhance github actions plan to include download of Eclipse binaries and installation of KTreemap; improve README.md.