### PR TITLE
OC-177 simplify project setup

### DIFF
--- a/.github/workflows/A-test-master.yml
+++ b/.github/workflows/A-test-master.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target/dependencies/eclipse
-          key: ${{ runner.os }}-eclipse-${{ hashFiles('**') }}
+          key: ${{ runner.os }}-eclipse-${{ hashFiles('clover-eclipse/clover-eclipse-libs/build.xml') }}
 
       - name: Prepare repacked third party libraries
         run: |

--- a/.github/workflows/A-test-master.yml
+++ b/.github/workflows/A-test-master.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+          cache: 'maven'
 
       - name: Prepare repacked third party libraries
         run: |
@@ -36,7 +37,7 @@ jobs:
            # an old maven-antrun-plugin does not recognize <target> tag
            sed -i -e 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
            # maven dependency plugin fails because of missing eclipse artifact so copy it manually
-           mkdir target/eclipse
+           mkdir -p target/eclipse
            cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse           
            mvn install -Dmdep.skip=true  
            cd ..

--- a/.github/workflows/A-test-master.yml
+++ b/.github/workflows/A-test-master.yml
@@ -20,6 +20,13 @@ jobs:
           java-version: 1.8
           cache: 'maven'
 
+      - name: Cache Eclipse binaries
+        id: cache-eclipse
+        uses: actions/cache@v3
+        with:
+          path: target/dependencies/eclipse
+          key: ${{ runner.os }}-eclipse-${{ hashFiles('**') }}
+
       - name: Prepare repacked third party libraries
         run: |
           mvn install -f clover-core-libs/jarjar/pom.xml

--- a/.github/workflows/A-test-master.yml
+++ b/.github/workflows/A-test-master.yml
@@ -34,7 +34,7 @@ jobs:
            cd ktreemap
            git checkout ktreemap-1.1.0-atlassian-01           
            # an old maven-antrun-plugin does not recognize <target> tag
-           sed -i 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
+           sed -i -e 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
            # maven dependency plugin fails because of missing eclipse artifact so copy it manually
            mkdir target/eclipse
            cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse           

--- a/.github/workflows/A-test-master.yml
+++ b/.github/workflows/A-test-master.yml
@@ -34,7 +34,7 @@ jobs:
            cd ktreemap
            git checkout ktreemap-1.1.0-atlassian-01           
            # an old maven-antrun-plugin does not recognize <target> tag
-           sed -i 's/<artifactId>maven-antrun-plugin</artifactId>/<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>' pom.xml
+           sed -i 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
            # maven dependency plugin fails because of missing eclipse artifact so copy it manually
            mkdir target/eclipse
            cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse           

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ git checkout ktreemap-1.1.0-atlassian-01
 # an old maven-antrun-plugin does not recognize <target> tag
 sed -i -e 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
 # maven-dependency-plugin fails because of missing eclipse artifact so copy JARs manually
-mkdir target/eclipse; cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse
+mkdir -p target/eclipse; cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse
 mvn install -Dmdep.skip=true  
 cd ..
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://bitbucket.org/atlassian/ktreemap
 cd ktreemap
 git checkout ktreemap-1.1.0-atlassian-01
 # an old maven-antrun-plugin does not recognize <target> tag
-sed -i 's/<artifactId>maven-antrun-plugin</artifactId>/<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>' pom.xml
+sed -i 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
 # maven-dependency-plugin fails because of missing eclipse artifact so copy JARs manually
 mkdir target/eclipse; cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse
 mvn install -Dmdep.skip=true  

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://bitbucket.org/atlassian/ktreemap
 cd ktreemap
 git checkout ktreemap-1.1.0-atlassian-01
 # an old maven-antrun-plugin does not recognize <target> tag
-sed -i 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
+sed -i -e 's@<artifactId>maven-antrun-plugin</artifactId>@<artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version>@' pom.xml
 # maven-dependency-plugin fails because of missing eclipse artifact so copy JARs manually
 mkdir target/eclipse; cp ../target/dependencies/eclipse/4.4/plugins/*.jar target/eclipse
 mvn install -Dmdep.skip=true  


### PR DESCRIPTION
OC-177: simplify Eclipse setup, download binaries from the website if they're not stored as Maven artifacts; also drop Eclipse 4.2 and 4.3 in build files; enhance github actions plan to include download of Eclipse binaries and installation of KTreemap; improve README.md.