### PR TITLE
OC-184: Add support for type use annotations in super/extends clause in generics

### DIFF
--- a/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
+++ b/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
@@ -871,7 +871,7 @@ singleTypeArgument {
 
         (   // I'm pretty sure Antlr generates the right thing here:
             options{generateAmbigWarnings=false;}:
-            ("extends"|"super") (type=classTypeSpec | type=builtInTypeSpec | QUESTION)
+            ("extends"|"super") ( options { greedy=true; }: ann=annotation )* (type=classTypeSpec | type=builtInTypeSpec | QUESTION)
         )?
     ;
 

--- a/clover-core/src/test/resources/javasyntax1.8/typeannotation/fielddeclarationgenerics/TypeAnnotationInFieldDeclarationGenerics.java
+++ b/clover-core/src/test/resources/javasyntax1.8/typeannotation/fielddeclarationgenerics/TypeAnnotationInFieldDeclarationGenerics.java
@@ -7,18 +7,37 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.HashMap;
 
-public class TypeAnnotationInFieldDeclarationGenerics {
-    private final HashMap<@AnnotationForType1 String, String> map = new HashMap<>();
+/* Testcase for singleTypeArgument */
+public class TypeAnnotationInFieldDeclarationGenerics<T> {
+    private final HashMap<@AnnotationForType1 String, String> map1 = new HashMap<>();
+    private final HashMap<@AnnotationForType1 @AnnotationForType2 String, String> map2 = new HashMap<>();
+    private final HashMap<String, @AnnotationForType1 int[]> map3 = new HashMap<>();
+    private final HashMap<String, @AnnotationForType1 @AnnotationForType2 T> map4 = new HashMap<>();
+    private final HashMap<String, @AnnotationForType1 ?> map5 = new HashMap<>();
+    private final HashMap<String, @AnnotationForType1 @AnnotationForType2 ?> map6 = new HashMap<>();
+    private final HashMap<String, @AnnotationForType1 ? extends @AnnotationForType1 int[]> map7 = new HashMap<>();
+    private final HashMap<String, @AnnotationForType1 @AnnotationForType2 ? super @AnnotationForType1 @AnnotationForType2 T> map8 = new HashMap<>();
 
     public static void main(String args[]) {
-        TypeAnnotationInFieldDeclarationGenerics j = new TypeAnnotationInFieldDeclarationGenerics();
+        TypeAnnotationInFieldDeclarationGenerics<?> j = new TypeAnnotationInFieldDeclarationGenerics<Object>();
         j.getSize();
     }
     public void getSize() {
-        System.out.println(map.size());
+        System.out.println(map1.size());
+        System.out.println(map2.size());
+        System.out.println(map3.size());
+        System.out.println(map4.size());
+        System.out.println(map5.size());
+        System.out.println(map6.size());
+        System.out.println(map7.size());
+        System.out.println(map8.size());
     }
 }
 
 @Retention(RUNTIME) @Target({ElementType.TYPE_USE})
 @interface AnnotationForType1 {
+}
+
+@Retention(RUNTIME) @Target({ElementType.TYPE_USE})
+@interface AnnotationForType2 {
 }


### PR DESCRIPTION
Closes #184.

- Add support for type use annotations in super/extends clause in generics