### PR TITLE
OC-237: the instanceof pattern matching allows to make the variable final

### DIFF
--- a/clover-core/src/main/java/com/atlassian/clover/instr/java/InstanceOfStateDetector.java
+++ b/clover-core/src/main/java/com/atlassian/clover/instr/java/InstanceOfStateDetector.java
@@ -5,6 +5,7 @@ package com.atlassian.clover.instr.java;
  * <pre>
  *   obj instanceof String
  *   obj instanceof String str
+ *   obj instanceof final String str
  * </pre>
  */
 public class InstanceOfStateDetector implements CloverTokenConsumer {

--- a/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
+++ b/clover-core/src/main/java/com/atlassian/clover/instr/java/java.g
@@ -3277,6 +3277,9 @@ relationalExpression returns [int complexity]
                 }
             )*
         |
+            (INSTANCEOF FINAL type=typeSpec IDENT) =>
+            INSTANCEOF FINAL type=typeSpec IDENT
+        |
             (INSTANCEOF type=typeSpec IDENT) =>
             INSTANCEOF type=typeSpec IDENT
         |

--- a/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax16CompilationTest.groovy
+++ b/clover-core/src/test/groovy/com/atlassian/clover/JavaSyntax16CompilationTest.groovy
@@ -67,9 +67,11 @@ class JavaSyntax16CompilationTest extends JavaSyntaxCompilationTestBase {
         final String fileName = "Java16InstanceOfPatternMatching.java"
         instrumentAndCompileSourceFile(srcDir, mGenSrcDir, fileName, JavaEnvUtils.JAVA_16)
         assertFileMatches(fileName, R_INC + "System\\.out\\.println\\(\"obj is String", false)
+        assertFileMatches(fileName, R_INC + "System\\.out\\.println\\(\"obj is final String", false)
 
         executeMainClasses("Java16InstanceOfPatternMatching")
         assertExecOutputContains("obj is String = a string", false)
+        assertExecOutputContains("obj is final String = a final string", false)
         assertExecOutputContains("obj is not null and is an Object and not String or Integer", false)
     }
 

--- a/clover-core/src/test/resources/javasyntax16/Java16InstanceOfPatternMatching.java
+++ b/clover-core/src/test/resources/javasyntax16/Java16InstanceOfPatternMatching.java
@@ -8,6 +8,7 @@ public class Java16InstanceOfPatternMatching {
 
     public static void main(String[] args) {
         instanceOfCasting();
+        instanceOfCastingWithFinal();
         instanceOfInExpressions();
         instanceOfCastingVisibilityLimitations();
         detectionOfInstanceOfWithCasting();
@@ -19,6 +20,15 @@ public class Java16InstanceOfPatternMatching {
             System.out.println("obj is String = " + str);
         } else {
             System.out.println("obj is Object = " + obj);
+        }
+    }
+
+    private static void instanceOfCastingWithFinal() {
+        Object obj = "a final string";
+        if (obj instanceof final String str) {
+            System.out.println("obj is final String = " + str);
+        } else {
+            System.out.println("obj is final Object = " + obj);
         }
     }
 


### PR DESCRIPTION
... so the final keywords is allowed before type name; modified java.g to allow it; also modified InstanceOfStateDetector to ensure that the variant with the final keyword will not get branch instrumentation