### PR TITLE
OC-278: Build and test on JDK25

### DIFF
--- a/.github/workflows/A-build-and-test-jdk25.yml
+++ b/.github/workflows/A-build-and-test-jdk25.yml
@@ -1,0 +1,55 @@
+name: A Build and test on JDK25
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: temurin
+          cache: maven
+
+      - name: Cache Eclipse binaries
+        id: cache-eclipse
+        uses: actions/cache@v4
+        with:
+          path: clover-eclipse-libs/target/download
+          key: ${{ runner.os }}-eclipse-${{ hashFiles('clover-eclipse-libs/pom.xml') }}
+
+      - name: Cache IDEA binaries
+        id: cache-idea
+        uses: actions/cache@v4
+        with:
+          path: clover-idea-libs/target/download
+          key: ${{ runner.os }}-idea-${{ hashFiles('clover-idea-libs/pom.xml') }}
+
+      - name: Prepare third party libraries
+        run: |
+          mvn --batch-mode install -Pworkspace-setup -f clover-core-libs/pom.xml
+          mvn --batch-mode install -Pworkspace-setup -f clover-eclipse-libs/pom.xml
+          mvn --batch-mode install -Pworkspace-setup -f clover-idea-libs/pom.xml
+
+      - name: Download KTreemap fork
+        run: |
+          wget https://packages.atlassian.com/mvn/maven-atlassian-external/net/sf/jtreemap/ktreemap/1.1.0-atlassian-01/ktreemap-1.1.0-atlassian-01.jar
+          wget https://packages.atlassian.com/mvn/maven-atlassian-external/net/sf/jtreemap/ktreemap/1.1.0-atlassian-01/ktreemap-1.1.0-atlassian-01.pom
+          mvn --batch-mode install:install-file -Dfile=ktreemap-1.1.0-atlassian-01.jar -DpomFile=ktreemap-1.1.0-atlassian-01.pom
+
+      - name: Compile and pack all modules
+        run: |
+          mvn --batch-mode install -DskipTests=true
+
+      - name: Run tests for runtime, core, groovy, ant
+        run: |
+          mvn --batch-mode verify -pl clover-runtime,clover-core,clover-groovy,clover-ant

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/openclover/clover/A-build-and-test-jdk11.yml?label=JDK11)](https://github.com/openclover/clover/actions/workflows/A-build-and-test-jdk11.yml)
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/openclover/clover/A-build-and-test-jdk17.yml?label=JDK17)](https://github.com/openclover/clover/actions/workflows/A-build-and-test-jdk17.yml)
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/openclover/clover/A-build-and-test-jdk21.yml?label=JDK21)](https://github.com/openclover/clover/actions/workflows/A-build-and-test-jdk21.yml)
+[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/openclover/clover/A-build-and-test-jdk25.yml?label=JDK25)](https://github.com/openclover/clover/actions/workflows/A-build-and-test-jdk25.yml)
 
 
 [![GitHub milestone details](https://img.shields.io/github/milestones/progress-percent/openclover/clover/11)](https://github.com/openclover/clover/milestone/11)


### PR DESCRIPTION
Added a job to run against JDK25.

It DOES NOT add support for new language features, it just tests existing runtime/testsuite against Java 25.