### PR TITLE
OC-192 support groovy 4

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,3 +1,4 @@
 # Memory Index
 
 - [Non-instrumentable coverage state](non-instrumentable-coverage-state.md) — Idea: add NON_INSTRUMENTABLE state for try-with-resources resources and similar injection-impossible sites
+- [Groovy 4 Language Instrumentation Plan](groovy4-language-instrumentation.md) — OC-192: implementation plan for Groovy 4 support; switch expressions, records, sealed classes, GINQ

--- a/.claude/memory/groovy4-language-instrumentation.md
+++ b/.claude/memory/groovy4-language-instrumentation.md
@@ -1,0 +1,441 @@
+# OC-192: Groovy 4 Language Instrumentation Plan
+
+## Context
+
+Branch: `OC-192-support-groovy-4`
+
+Groovy 4 was already adopted in the test infrastructure (pom.xml uses `org.apache.groovy:groovy:4.0.15`).
+The clover-groovy module already compiles and runs tests against Groovy 4.
+This ticket is about verifying and extending **Clover instrumentation** to correctly handle the new
+language constructs introduced in Groovy 4.
+
+## What Changed in Groovy 4 vs Groovy 3
+
+### Maven Group ID
+| Groovy 2/3 | Groovy 4 |
+|------------|---------|
+| `org.codehaus.groovy:groovy` | `org.apache.groovy:groovy` |
+
+Java package names (`org.codehaus.groovy.*`) are **unchanged** in Groovy 4 — backward compatible.
+
+### AST Node Inventory (key finding)
+Groovy 4 (4.0.15) has **exactly the same `org.codehaus.groovy.ast.expr.*` and `org.codehaus.groovy.ast.stmt.*` classes** as Groovy 3:
+- No new `SwitchExpression` class
+- No new expression/statement nodes for records or sealed classes
+
+New AST tooling classes are in `org.apache.groovy.ast.tools.*` but they are not expression/statement nodes.
+
+### How New Groovy 4 Syntax Compiles to AST
+
+**Switch expressions** (`switch(x) { case 1 -> "one" ... }`)
+- Compiled to a `ClosureExpression` wrapping a `SwitchStatement`, immediately `.call()`ed.
+- The `switch` variable is saved to a synthetic `__$$sev0` local before the closure.
+- Pattern: `{ -> __$$sev0 = x; switch(__$$sev0) { case 1: return "one" ... } }.call()`
+- When no `default` is present, Groovyc **injects a synthetic default that returns null**.
+  That injected default statement has source coordinates `[-1:-1 .. -1:-1]` — no source position.
+- Void switch expression (side-effect cases, e.g. `case 1 -> println("one")`) is valid.
+  It compiles to an `ExpressionStatement` wrapping the closure `.call()`, rather than `ReturnStatement`.
+
+**Records** (`record Point(int x, int y) { ... }`)
+- Compile to regular `ClassNode` with annotations:
+  `@RecordBase`, `@RecordOptions`, `@TupleConstructor`, `@KnownImmutable`, `@POJO`, `@CompileStatic`
+- Auto-generated methods (not `synthetic=true`): `toString`, `equals`, `hashCode`, `getAt`,
+  `toList`, `toMap`, `size`
+- User-defined methods within the record body are also present.
+- Because these are not flagged `synthetic`, Clover will attempt to instrument them.
+  Their bodies do contain statements (Groovy generates real AST for them), so they will appear in
+  coverage reports. This is acceptable — they are real executable code.
+
+**Sealed classes/interfaces** (`sealed interface Shape permits Circle, Square`)
+- Compile to `ClassNode` with `@groovy.transform.Sealed` annotation only.
+- No special AST nodes. The `permits` clause is encoded as annotation attributes, not as AST expressions
+  that would be visited by `InstrumentingCodeVisitor`.
+- No instrumentation changes needed; tests verify no crash.
+
+**Enhanced range syntax** (`0<..<3`, `3<..5`, `0<..3`)
+- Parses to `RangeExpression` nodes (same class as before, with `exclusiveLeft`/`exclusiveRight` flags).
+- No instrumentation changes needed; tests verify correct handling.
+
+**Decimal literals without leading zero** (`.5` equals `0.5`)
+- Parses to `ConstantExpression` as before (value `0.5`).
+- No instrumentation changes needed; tests verify no crash.
+
+### Features NOT in scope (experimental/incubating in Groovy 4)
+- GINQ (Groovy-Integrated Query) — incubating, not enabled by default
+- Macro methods (`SV()`, `SVI()`, etc.) — compiler debugging tools, not user-facing syntax
+
+## Backward Compatibility Strategy (Groovy 2 runtime)
+
+Pattern established in OC-121 for `LambdaExpression` and `MethodReferenceExpression`:
+- Do NOT `import` Groovy 4-only classes directly
+- Use `Class.forName(...)` with `catch (ClassNotFoundException ignored)` in a static initializer
+- Store in a `static final Class<?>` field
+- Check with `FIELDNAME != null && FIELDNAME.isInstance(expr)` before casting
+
+As of Groovy 4, no new AST expression/statement classes were introduced, so **no new Class.forName
+workarounds are needed for Groovy 4 specifically**. This remains a concern if a future version adds new nodes.
+
+## Scope: clover-groovy Module Only
+
+All changes are expected to stay within `clover-groovy/`:
+- `src/main/java/org/openclover/groovy/instr/` — instrumentation logic
+- `src/test/groovy/org/openclover/groovy/instr/` — integration tests
+- No changes expected in clover-core, clover-ant, or other modules.
+
+## Implementation Tasks
+
+### 1. Code Samples for Each Feature
+
+Each snippet is used twice in tests: once plain, once with `@groovy.transform.CompileStatic`
+on the class/method under test (see "Test Structure" below).
+
+---
+
+**Switch expression — arrow form with default** (value-returning)
+```groovy
+class SwitchArrow {
+    static String classify(int n) {
+        return switch (n) {
+            case 1 -> "one"
+            case 2 -> "two"
+            default -> "other"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(2) == "two"
+        assert classify(99) == "other"
+    }
+}
+```
+Expected (call sequence: `classify(1)`, `classify(2)`, `classify(99)`):
+- closure wrapper: hit=3
+- case-1 body: hit=1
+- case-2 body: hit=1
+- default body: hit=1
+- synthetic null-branch (injected default when user writes `default ->`): not present (Groovyc does
+  not inject it when `default` is written)
+
+---
+
+**Switch expression — arrow form without default** (value-returning, null fallthrough)
+```groovy
+class SwitchArrowNoDefault {
+    static String classify(int n) {
+        return switch (n) {
+            case 1 -> "one"
+            case 2 -> "two"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(99) == null
+    }
+}
+```
+Expected (call sequence: `classify(1)`, `classify(99)`):
+- closure wrapper: hit=2
+- case-1 body: hit=1
+- case-2 body: hit=0
+- Groovyc-injected default (returns null): hit=1, but **source coordinates are `[-1:-1..-1:-1]`**.
+
+Instrumentation: The injected default has no source position. **Decision: synthesize a 1-character
+region at the closing `}` of the enclosing `SwitchStatement`.**
+
+Concretely, inside `InstrumentingCodeVisitor.visitSwitch(SwitchStatement statement)` we already have
+both the parent `SwitchStatement` (with valid coordinates) and the default `Statement` (with -1,-1)
+at the same time. When `statement.getDefaultStatement().getLineNumber() == -1`, before calling
+`statementInstrumenter.instrumentBlockStatement(...)`, patch or wrap the default statement with a
+synthesized source region:
+
+```
+synthesizedLine   = statement.getLastLineNumber()
+synthesizedCol    = statement.getLastColumnNumber() - 1   // the '}' character (1-indexed)
+synthesizedEndCol = statement.getLastColumnNumber()        // exclusive end, one past '}'
+```
+
+AST inspection confirms: `SwitchStatement` for a 7-line class has coordinates `[4:16 .. 7:10]`,
+so `lastColumnNumber=10` and the `}` sits at column 9. The synthesized region is `[7:9 .. 7:10]`,
+a single character.
+
+The `EmptyStatement` singleton (`EmptyStatement$1`) cannot have its coordinates mutated (it's shared).
+Instead, pass the synthesized region directly to whatever overload of `StatementInstrumenter` records
+the statement — or wrap the empty statement in a new `BlockStatement` with those coordinates before
+handing it to `instrumentBlockStatement`.
+
+---
+
+**Switch expression — yield form with default**
+```groovy
+class SwitchYield {
+    static String classify(int n) {
+        return switch (n) {
+            case 1: yield "one"
+            case 2: yield "two"
+            default: yield "other"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(99) == "other"
+    }
+}
+```
+Expected (call sequence: `classify(1)`, `classify(99)`):
+- closure wrapper: hit=2
+- case-1 body: hit=1 (case-2: hit=0, default: hit=1)
+- Groovyc does NOT inject a synthetic null-branch when `default` is present
+
+---
+
+**Switch expression — yield form without default** (null fallthrough)
+```groovy
+class SwitchYieldNoDefault {
+    static String classify(int n) {
+        return switch (n) {
+            case 1: yield "one"
+            case 2: yield "two"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(99) == null
+    }
+}
+```
+Expected: same null-branch consideration as arrow-no-default.
+
+---
+
+**Switch expression — void (side-effect cases)**
+```groovy
+class SwitchVoid {
+    static List<String> log = []
+    static void classify(int n) {
+        switch (n) {
+            case 1 -> log.add("one")
+            case 2 -> log.add("two")
+        }
+    }
+    static void main(String[] args) {
+        classify(1)
+        classify(99)
+        assert log == ["one"]
+    }
+}
+```
+Note: void switch compiles to `ExpressionStatement` (not `ReturnStatement`) wrapping the closure call.
+The instrumentation path differs slightly from the value-returning form; verify both paths are covered.
+Expected:
+- closure wrapper: hit=2
+- case-1 body: hit=1
+- case-2 body: hit=0
+- injected null-default: hit=1 (same -1,-1 source position issue)
+
+---
+
+**Record — generated and user-defined methods**
+```groovy
+record Point(int x, int y) {
+    static Point origin() { new Point(0, 0) }
+    static void main(String[] args) {
+        def p = new Point(3, 4)
+        assert p.x() == 3
+        assert p.y() == 4
+        assert p.toString() != null
+        def o = origin()
+        assert o.x() == 0
+    }
+}
+```
+Expected:
+- `origin()` method: 1 statement (`new Point(0,0)`), hit=1
+- `toString()` (generated): appears in coverage model; body has ≥1 statement; hit=1 because `main` calls `p.toString()`
+- `hashCode()` (generated): appears in coverage model; hit=0 (not called in main)
+- `equals()` (generated): appears in coverage model; hit=0 (not called in main)
+- Constructor (via `TupleConstructor`): may or may not appear depending on how Clover handles
+  `@TupleConstructor`-generated constructors; verify no crash
+
+---
+
+**Sealed interface — basic verification**
+```groovy
+sealed interface Shape permits Circle, Square {}
+final class Circle implements Shape {
+    final float radius
+    Circle(float r) { this.radius = r }
+}
+final class Square implements Shape {
+    final float side
+    Square(float s) { this.side = s }
+}
+class SealedTest {
+    static String name(Shape s) {
+        if (s instanceof Circle) return "circle"
+        if (s instanceof Square) return "square"
+        return "unknown"
+    }
+    static void main(String[] args) {
+        assert name(new Circle(1.0f)) == "circle"
+        assert name(new Square(1.0f)) == "square"
+    }
+}
+```
+No special expected hit-count structure; test primarily verifies no crash during instrumentation and
+that regular method/branch counts are recorded correctly.
+
+---
+
+**Enhanced range syntax**
+```groovy
+class RangeTest {
+    static List<Integer> leftOpen(int from, int to) {
+        return (from<..to).toList()
+    }
+    static List<Integer> bothOpen(int from, int to) {
+        return (from<..<to).toList()
+    }
+    static void main(String[] args) {
+        assert leftOpen(0, 3) == [1, 2, 3]
+        assert bothOpen(0, 3) == [1, 2]
+    }
+}
+```
+Expected: methods `leftOpen` and `bothOpen` each have 1 statement, hit=1.
+
+---
+
+**Decimal literal without leading zero**
+```groovy
+class DecimalLiteralTest {
+    static double half() { .5 }
+    static double quarter() { .25 }
+    static void main(String[] args) {
+        assert half() == 0.5
+        assert quarter() == 0.25
+    }
+}
+```
+Expected: each method has 1 statement, hit=1.
+
+---
+
+### 2. Test Class Structure
+
+```groovy
+package org.openclover.groovy.instr
+
+import groovy.transform.CompileStatic
+import org.openclover.buildutil.test.junit.GroovyVersionStart
+import org.openclover.core.CloverDatabase
+import org.openclover.core.CodeType
+import org.openclover.core.CoverageDataSpec
+import org.openclover.core.api.registry.MethodInfo
+import org.openclover.core.api.registry.PackageInfo
+import org.openclover.core.api.registry.StatementInfo
+import org.openclover.core.registry.entities.FullClassInfo
+import org.openclover.core.registry.entities.FullFileInfo
+
+@CompileStatic
+class Groovy4CoverageRecordingTest extends TestBase {
+
+    Groovy4CoverageRecordingTest(String testName) { super(testName) }
+    Groovy4CoverageRecordingTest(String methodName, String specificName,
+                                  File groovyAllJar, List<File> additionalGroovyJars) {
+        super(methodName, specificName, groovyAllJar, additionalGroovyJars)
+    }
+
+    // Each test method below is exercised twice by the TestSuite:
+    //   once with plain Groovy source, once with @CompileStatic added to the tested class.
+
+    @GroovyVersionStart("4.0.0")
+    void testSwitchArrowWithDefaultHitCounts() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testSwitchArrowNoDefaultNullBranch() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testSwitchYieldWithDefaultHitCounts() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testSwitchYieldNoDefaultNullBranch() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testSwitchVoidHitCounts() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testRecordGeneratedAndUserMethodHitCounts() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testSealedClassesDoNotCrash() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testEnhancedRangeHitCounts() { ... }
+
+    @GroovyVersionStart("4.0.0")
+    void testDecimalLiteralWithoutLeadingZero() { ... }
+}
+```
+
+**Running each test with and without `@CompileStatic`**: look at how `Groovy3CoverageRecordingTest`
+achieves this via the `TestSuite` and the constructor that accepts `specificName`. The suite likely
+calls each test method twice with different `groovyAllJar` / configuration. Replicate that pattern.
+
+### 3. Register in TestSuite
+
+Find `TestSuite.groovy` (or `.java`) in `clover-groovy/src/test/groovy/org/openclover/groovy/instr/`
+and add `Groovy4CoverageRecordingTest` the same way `Groovy3CoverageRecordingTest` was added.
+
+### 4. Potential Instrumentation Issues to Investigate
+
+**Issue A: Injected default branch with `[-1:-1..-1:-1]` source position**
+Switch expressions without an explicit `default` have a Groovyc-injected `EmptyStatement` singleton
+with coordinates `[-1:-1..-1:-1]`. Fix: inside `InstrumentingCodeVisitor.visitSwitch()`, detect
+`getDefaultStatement().getLineNumber() == -1` and synthesize a 1-character region at the closing `}`
+of the `SwitchStatement` using `(lastLineNumber, lastColumnNumber-1) .. (lastLineNumber, lastColumnNumber)`.
+Because `EmptyStatement$1` is a singleton and immutable, create a wrapper (e.g. a new `BlockStatement`
+or pass the synthesized coordinates directly to the recording call) rather than mutating it.
+
+**Issue B: Record auto-generated methods with `@CompileStatic`**
+Records automatically get `@CompileStatic` on all generated methods. Their bodies run through the
+CompileStatic instrumentation path. Check for NPE in `CloverAstTransformerInstructionSelection`
+when processing generated method bodies that may have unusual AST shapes.
+
+**Issue C: Switch expression variable scope balance**
+The compiler introduces a synthetic `__$$sev0` local. Verify that `pushVariableScope` /
+`popVariableScope` calls in `InstrumentingCodeVisitor` remain balanced when visiting the wrapping closure.
+
+**Issue D: Sealed class `@Sealed` annotation on interfaces**
+Verify that the `visitAnnotations()` no-op override in `InstrumentingCodeVisitor` correctly suppresses
+visiting annotation attribute expressions (the `permits` class list is stored there).
+
+### 5. Key Files to Read Before Starting
+
+```
+clover-groovy/src/main/java/org/openclover/groovy/instr/InstrumentingCodeVisitor.java
+clover-groovy/src/main/java/org/openclover/groovy/instr/OperatorsInstrumenter.java
+clover-groovy/src/main/java/org/openclover/groovy/instr/StatementInstrumenter.java
+clover-groovy/src/main/java/org/openclover/groovy/instr/CloverAstTransformerInstructionSelection.java
+clover-groovy/src/main/java/org/openclover/groovy/instr/GroovyUtils.java
+clover-groovy/src/test/groovy/org/openclover/groovy/instr/Groovy3CoverageRecordingTest.groovy
+clover-groovy/src/test/groovy/org/openclover/groovy/instr/TestBase.groovy
+```
+
+### 6. Key Design Decisions
+
+- No new AST node classes in Groovy 4 — no new visitor methods needed in `InstrumentingCodeVisitor`.
+- Switch expressions desugar to closures wrapping `SwitchStatement`; instrumentation flows through
+  existing closure and switch paths.
+- Record-generated methods are instrumented like any other method; they appear in coverage reports.
+  No exclusion mechanism is planned (impossible to distinguish user-overridden vs generated when both
+  share the same name and class annotation).
+- The Groovy 2 Class.forName compatibility strategy is **not needed** for Groovy 4 features.
+- Focus: write tests, run them, fix whatever breaks.
+
+## Reference Commits
+
+- OC-121 (Groovy 3 support): `3905c046..9600b99d` on master
+  - Key: `e913ab23` — Class.forName pattern for LambdaExpression/MethodReferenceExpression
+  - Key: `0f98ca2e` — DoWhileStatement instrumentation
+  - Key: `130ba153` — default interface method instrumentation
+- OC-31 (CompileStatic support): `3905c046` — see full commit message for split-phase strategy

--- a/.claude/memory/groovy4-language-instrumentation.md
+++ b/.claude/memory/groovy4-language-instrumentation.md
@@ -1,13 +1,14 @@
-# OC-192: Groovy 4 Language Instrumentation Plan
+# OC-192: Groovy 4 Language Instrumentation — Implemented
 
 ## Context
 
 Branch: `OC-192-support-groovy-4`
 
 Groovy 4 was already adopted in the test infrastructure (pom.xml uses `org.apache.groovy:groovy:4.0.15`).
-The clover-groovy module already compiles and runs tests against Groovy 4.
-This ticket is about verifying and extending **Clover instrumentation** to correctly handle the new
-language constructs introduced in Groovy 4.
+The clover-groovy module already compiled and ran tests against Groovy 4.
+This ticket verified and extended **Clover instrumentation** to correctly handle new Groovy 4 constructs.
+
+---
 
 ## What Changed in Groovy 4 vs Groovy 3
 
@@ -29,408 +30,128 @@ New AST tooling classes are in `org.apache.groovy.ast.tools.*` but they are not 
 
 **Switch expressions** (`switch(x) { case 1 -> "one" ... }`)
 - Compiled to a `ClosureExpression` wrapping a `SwitchStatement`, immediately `.call()`ed.
-- The `switch` variable is saved to a synthetic `__$$sev0` local before the closure.
+- The `switch` variable is saved to a synthetic `__$$sev0` local inside the closure.
 - Pattern: `{ -> __$$sev0 = x; switch(__$$sev0) { case 1: return "one" ... } }.call()`
-- When no `default` is present, Groovyc **injects a synthetic default that returns null**.
-  That injected default statement has source coordinates `[-1:-1 .. -1:-1]` — no source position.
-- Void switch expression (side-effect cases, e.g. `case 1 -> println("one")`) is valid.
-  It compiles to an `ExpressionStatement` wrapping the closure `.call()`, rather than `ReturnStatement`.
+- When no `default` is present, Groovyc **injects `EmptyStatement.INSTANCE` as the default**.
+  That singleton has source coordinates `[-1:-1 .. -1:-1]` — no source position.
+- Void switch expression (side-effect cases, e.g. `case 1 -> println("one")`) compiles to an
+  `ExpressionStatement` wrapping the closure `.call()`, rather than a `ReturnStatement`.
 
 **Records** (`record Point(int x, int y) { ... }`)
 - Compile to regular `ClassNode` with annotations:
   `@RecordBase`, `@RecordOptions`, `@TupleConstructor`, `@KnownImmutable`, `@POJO`, `@CompileStatic`
-- Auto-generated methods (not `synthetic=true`): `toString`, `equals`, `hashCode`, `getAt`,
+- Auto-generated methods (NOT flagged `synthetic=true`): `toString`, `equals`, `hashCode`, `getAt`,
   `toList`, `toMap`, `size`
-- User-defined methods within the record body are also present.
-- Because these are not flagged `synthetic`, Clover will attempt to instrument them.
-  Their bodies do contain statements (Groovy generates real AST for them), so they will appear in
-  coverage reports. This is acceptable — they are real executable code.
+- Because these are not flagged `synthetic`, Clover instruments them normally.
+  They appear in coverage reports, which is acceptable — they are real executable code.
 
 **Sealed classes/interfaces** (`sealed interface Shape permits Circle, Square`)
 - Compile to `ClassNode` with `@groovy.transform.Sealed` annotation only.
-- No special AST nodes. The `permits` clause is encoded as annotation attributes, not as AST expressions
-  that would be visited by `InstrumentingCodeVisitor`.
-- No instrumentation changes needed; tests verify no crash.
+- No special AST nodes. The `permits` clause is annotation attributes, not visited expressions.
+- No instrumentation changes needed.
 
 **Enhanced range syntax** (`0<..<3`, `3<..5`, `0<..3`)
 - Parses to `RangeExpression` nodes (same class as before, with `exclusiveLeft`/`exclusiveRight` flags).
-- No instrumentation changes needed; tests verify correct handling.
+- No instrumentation changes needed.
 
 **Decimal literals without leading zero** (`.5` equals `0.5`)
 - Parses to `ConstantExpression` as before (value `0.5`).
-- No instrumentation changes needed; tests verify no crash.
+- No instrumentation changes needed.
 
 ### Features NOT in scope (experimental/incubating in Groovy 4)
 - GINQ (Groovy-Integrated Query) — incubating, not enabled by default
 - Macro methods (`SV()`, `SVI()`, etc.) — compiler debugging tools, not user-facing syntax
+
+---
+
+## Instrumentation Fix Implemented
+
+### The Problem
+Switch expressions (and ALL switches) without an explicit `default` use `EmptyStatement.INSTANCE`
+as the default branch. This singleton has coordinates `[-1:-1..-1:-1]`. The old `visitSwitch`
+called `instrumentBlockStatement(EmptyStatement.INSTANCE)`, which fell into the else-branch
+("don't know how to handle it") and returned unchanged — the fallthrough branch was never
+registered in the coverage model.
+
+### The Solution: `MutableEmptyStatement` + `== EmptyStatement.INSTANCE` check
+
+- **New `MutableEmptyStatement` class** (extends `EmptyStatement`) — a type-marker subclass
+  instantiated with synthesized coordinates. Extends rather than replaces `EmptyStatement` so
+  Groovy's own `instanceof EmptyStatement` checks in code generation continue to work. `ASTNode`
+  setters don't throw; no override needed.
+
+- **`InstrumentingCodeVisitor.visitSwitch`** — detects the injected sentinel with
+  `defaultStatement == EmptyStatement.INSTANCE` (reference equality, not `getLineNumber() == -1`).
+  The reference check is precise: `getLineNumber() == -1` would also fire for any future synthetic
+  statement without source info, incorrectly replacing its body with just `R.inc()`. `INSTANCE` is
+  `public static final`, stable across Groovy 2/3/4, and the same object identity in the same JVM
+  as Groovyc. When matched, creates a `MutableEmptyStatement` at synthesized coordinates
+  `(lastLine, lastCol-1, lastLine, lastCol)` — a 1-char span at the closing `}` — and passes it
+  to `instrumentBlockStatement`.
+
+- **`StatementInstrumenter.instrumentBlockStatement`** — new `MutableEmptyStatement` branch
+  (before `TryCatchStatement`): calls `instrumentStmt` to register it in the model, then returns
+  only the `R.inc()` call. No `BlockStatement` wrapper needed — the null-return for switch
+  expressions comes from the enclosing closure falling off the end, not from the default statement.
+
+### Scope: broader than Groovy 4 only
+This fix applies to ALL Groovy versions — traditional `switch` statements without explicit
+`default` also use `EmptyStatement.INSTANCE`. The fix correctly adds coverage tracking for
+those too. `GroovyCoverageTest.testImplicitReturnsArePreserved` was updated:
+- `m.statements.size()` changed from 3 → 4 for both `implicitReturns` and `explicitReturns`
+- Added `assertStatement(m, at(11, 29, 11, 30), hits(0))` and `assertStatement(m, at(20, 29, 20, 30), hits(0))`
+
+---
+
+## Files Changed
+
+```
+clover-groovy/src/main/java/org/openclover/groovy/instr/
+  MutableEmptyStatement.java          ← NEW
+  InstrumentingCodeVisitor.java       ← visitSwitch: == EmptyStatement.INSTANCE check
+  StatementInstrumenter.java          ← instrumentBlockStatement: MutableEmptyStatement branch
+
+clover-groovy/src/test/groovy/org/openclover/groovy/instr/
+  Groovy4CoverageRecordingTest.groovy ← NEW — 9 test methods (@GroovyVersionStart("4.0.0"))
+  TestSuite.groovy                    ← +Groovy4CoverageRecordingTest in TEST_CLASSES_AND_SELECTORS
+  GroovyCoverageTest.groovy           ← testImplicitReturnsArePreserved: updated statement counts
+```
+
+---
+
+## Test Coverage
+
+`Groovy4CoverageRecordingTest` (9 tests, all passing with Groovy 4.0.15):
+
+| Test method | What it verifies |
+|---|---|
+| `testSwitchArrowWithDefaultHitCounts` | Arrow switch with explicit default; classify method hit=3 |
+| `testSwitchArrowNoDefaultNullBranch` | Arrow switch, no default; synthesized default at `at(6,9,6,10)` hit=1 |
+| `testSwitchYieldWithDefaultHitCounts` | Yield switch with explicit default; method hit counts |
+| `testSwitchYieldNoDefaultNullBranch` | Yield switch, no default; synthesized default hit=1 |
+| `testSwitchVoidHitCounts` | Void/side-effect switch; synthesized default at `at(7,9,7,10)` hit=1 |
+| `testRecordGeneratedAndUserMethodHitCounts` | Record: origin() hit=1, no crash on generated methods |
+| `testSealedClassesDoNotCrash` | Sealed interface/class; no crash during instrumentation |
+| `testEnhancedRangeHitCounts` | `<..` and `<..<` ranges; method hit counts |
+| `testDecimalLiteralWithoutLeadingZero` | `.5` and `.25` literals; method hit counts |
+
+Run command:
+```
+mvn test -pl clover-groovy -Dtest="Groovy4CoverageRecordingTest" -Dclover.test.groovyversion.includes=4.0
+```
+
+---
 
 ## Backward Compatibility Strategy (Groovy 2 runtime)
 
 Pattern established in OC-121 for `LambdaExpression` and `MethodReferenceExpression`:
 - Do NOT `import` Groovy 4-only classes directly
 - Use `Class.forName(...)` with `catch (ClassNotFoundException ignored)` in a static initializer
-- Store in a `static final Class<?>` field
-- Check with `FIELDNAME != null && FIELDNAME.isInstance(expr)` before casting
 
-As of Groovy 4, no new AST expression/statement classes were introduced, so **no new Class.forName
-workarounds are needed for Groovy 4 specifically**. This remains a concern if a future version adds new nodes.
-
-## Scope: clover-groovy Module Only
-
-All changes are expected to stay within `clover-groovy/`:
-- `src/main/java/org/openclover/groovy/instr/` — instrumentation logic
-- `src/test/groovy/org/openclover/groovy/instr/` — integration tests
-- No changes expected in clover-core, clover-ant, or other modules.
-
-## Implementation Tasks
-
-### 1. Code Samples for Each Feature
-
-Each snippet is used twice in tests: once plain, once with `@groovy.transform.CompileStatic`
-on the class/method under test (see "Test Structure" below).
+**Not needed for Groovy 4** — no new AST expression/statement classes were introduced.
+`MutableEmptyStatement` extends a class present since Groovy 1.x and is safe on all versions.
 
 ---
-
-**Switch expression — arrow form with default** (value-returning)
-```groovy
-class SwitchArrow {
-    static String classify(int n) {
-        return switch (n) {
-            case 1 -> "one"
-            case 2 -> "two"
-            default -> "other"
-        }
-    }
-    static void main(String[] args) {
-        assert classify(1) == "one"
-        assert classify(2) == "two"
-        assert classify(99) == "other"
-    }
-}
-```
-Expected (call sequence: `classify(1)`, `classify(2)`, `classify(99)`):
-- closure wrapper: hit=3
-- case-1 body: hit=1
-- case-2 body: hit=1
-- default body: hit=1
-- synthetic null-branch (injected default when user writes `default ->`): not present (Groovyc does
-  not inject it when `default` is written)
-
----
-
-**Switch expression — arrow form without default** (value-returning, null fallthrough)
-```groovy
-class SwitchArrowNoDefault {
-    static String classify(int n) {
-        return switch (n) {
-            case 1 -> "one"
-            case 2 -> "two"
-        }
-    }
-    static void main(String[] args) {
-        assert classify(1) == "one"
-        assert classify(99) == null
-    }
-}
-```
-Expected (call sequence: `classify(1)`, `classify(99)`):
-- closure wrapper: hit=2
-- case-1 body: hit=1
-- case-2 body: hit=0
-- Groovyc-injected default (returns null): hit=1, but **source coordinates are `[-1:-1..-1:-1]`**.
-
-Instrumentation: The injected default has no source position. **Decision: synthesize a 1-character
-region at the closing `}` of the enclosing `SwitchStatement`.**
-
-Concretely, inside `InstrumentingCodeVisitor.visitSwitch(SwitchStatement statement)` we already have
-both the parent `SwitchStatement` (with valid coordinates) and the default `Statement` (with -1,-1)
-at the same time. When `statement.getDefaultStatement().getLineNumber() == -1`, before calling
-`statementInstrumenter.instrumentBlockStatement(...)`, patch or wrap the default statement with a
-synthesized source region:
-
-```
-synthesizedLine   = statement.getLastLineNumber()
-synthesizedCol    = statement.getLastColumnNumber() - 1   // the '}' character (1-indexed)
-synthesizedEndCol = statement.getLastColumnNumber()        // exclusive end, one past '}'
-```
-
-AST inspection confirms: `SwitchStatement` for a 7-line class has coordinates `[4:16 .. 7:10]`,
-so `lastColumnNumber=10` and the `}` sits at column 9. The synthesized region is `[7:9 .. 7:10]`,
-a single character.
-
-The `EmptyStatement` singleton (`EmptyStatement$1`) cannot have its coordinates mutated (it's shared).
-Instead, pass the synthesized region directly to whatever overload of `StatementInstrumenter` records
-the statement — or wrap the empty statement in a new `BlockStatement` with those coordinates before
-handing it to `instrumentBlockStatement`.
-
----
-
-**Switch expression — yield form with default**
-```groovy
-class SwitchYield {
-    static String classify(int n) {
-        return switch (n) {
-            case 1: yield "one"
-            case 2: yield "two"
-            default: yield "other"
-        }
-    }
-    static void main(String[] args) {
-        assert classify(1) == "one"
-        assert classify(99) == "other"
-    }
-}
-```
-Expected (call sequence: `classify(1)`, `classify(99)`):
-- closure wrapper: hit=2
-- case-1 body: hit=1 (case-2: hit=0, default: hit=1)
-- Groovyc does NOT inject a synthetic null-branch when `default` is present
-
----
-
-**Switch expression — yield form without default** (null fallthrough)
-```groovy
-class SwitchYieldNoDefault {
-    static String classify(int n) {
-        return switch (n) {
-            case 1: yield "one"
-            case 2: yield "two"
-        }
-    }
-    static void main(String[] args) {
-        assert classify(1) == "one"
-        assert classify(99) == null
-    }
-}
-```
-Expected: same null-branch consideration as arrow-no-default.
-
----
-
-**Switch expression — void (side-effect cases)**
-```groovy
-class SwitchVoid {
-    static List<String> log = []
-    static void classify(int n) {
-        switch (n) {
-            case 1 -> log.add("one")
-            case 2 -> log.add("two")
-        }
-    }
-    static void main(String[] args) {
-        classify(1)
-        classify(99)
-        assert log == ["one"]
-    }
-}
-```
-Note: void switch compiles to `ExpressionStatement` (not `ReturnStatement`) wrapping the closure call.
-The instrumentation path differs slightly from the value-returning form; verify both paths are covered.
-Expected:
-- closure wrapper: hit=2
-- case-1 body: hit=1
-- case-2 body: hit=0
-- injected null-default: hit=1 (same -1,-1 source position issue)
-
----
-
-**Record — generated and user-defined methods**
-```groovy
-record Point(int x, int y) {
-    static Point origin() { new Point(0, 0) }
-    static void main(String[] args) {
-        def p = new Point(3, 4)
-        assert p.x() == 3
-        assert p.y() == 4
-        assert p.toString() != null
-        def o = origin()
-        assert o.x() == 0
-    }
-}
-```
-Expected:
-- `origin()` method: 1 statement (`new Point(0,0)`), hit=1
-- `toString()` (generated): appears in coverage model; body has ≥1 statement; hit=1 because `main` calls `p.toString()`
-- `hashCode()` (generated): appears in coverage model; hit=0 (not called in main)
-- `equals()` (generated): appears in coverage model; hit=0 (not called in main)
-- Constructor (via `TupleConstructor`): may or may not appear depending on how Clover handles
-  `@TupleConstructor`-generated constructors; verify no crash
-
----
-
-**Sealed interface — basic verification**
-```groovy
-sealed interface Shape permits Circle, Square {}
-final class Circle implements Shape {
-    final float radius
-    Circle(float r) { this.radius = r }
-}
-final class Square implements Shape {
-    final float side
-    Square(float s) { this.side = s }
-}
-class SealedTest {
-    static String name(Shape s) {
-        if (s instanceof Circle) return "circle"
-        if (s instanceof Square) return "square"
-        return "unknown"
-    }
-    static void main(String[] args) {
-        assert name(new Circle(1.0f)) == "circle"
-        assert name(new Square(1.0f)) == "square"
-    }
-}
-```
-No special expected hit-count structure; test primarily verifies no crash during instrumentation and
-that regular method/branch counts are recorded correctly.
-
----
-
-**Enhanced range syntax**
-```groovy
-class RangeTest {
-    static List<Integer> leftOpen(int from, int to) {
-        return (from<..to).toList()
-    }
-    static List<Integer> bothOpen(int from, int to) {
-        return (from<..<to).toList()
-    }
-    static void main(String[] args) {
-        assert leftOpen(0, 3) == [1, 2, 3]
-        assert bothOpen(0, 3) == [1, 2]
-    }
-}
-```
-Expected: methods `leftOpen` and `bothOpen` each have 1 statement, hit=1.
-
----
-
-**Decimal literal without leading zero**
-```groovy
-class DecimalLiteralTest {
-    static double half() { .5 }
-    static double quarter() { .25 }
-    static void main(String[] args) {
-        assert half() == 0.5
-        assert quarter() == 0.25
-    }
-}
-```
-Expected: each method has 1 statement, hit=1.
-
----
-
-### 2. Test Class Structure
-
-```groovy
-package org.openclover.groovy.instr
-
-import groovy.transform.CompileStatic
-import org.openclover.buildutil.test.junit.GroovyVersionStart
-import org.openclover.core.CloverDatabase
-import org.openclover.core.CodeType
-import org.openclover.core.CoverageDataSpec
-import org.openclover.core.api.registry.MethodInfo
-import org.openclover.core.api.registry.PackageInfo
-import org.openclover.core.api.registry.StatementInfo
-import org.openclover.core.registry.entities.FullClassInfo
-import org.openclover.core.registry.entities.FullFileInfo
-
-@CompileStatic
-class Groovy4CoverageRecordingTest extends TestBase {
-
-    Groovy4CoverageRecordingTest(String testName) { super(testName) }
-    Groovy4CoverageRecordingTest(String methodName, String specificName,
-                                  File groovyAllJar, List<File> additionalGroovyJars) {
-        super(methodName, specificName, groovyAllJar, additionalGroovyJars)
-    }
-
-    // Each test method below is exercised twice by the TestSuite:
-    //   once with plain Groovy source, once with @CompileStatic added to the tested class.
-
-    @GroovyVersionStart("4.0.0")
-    void testSwitchArrowWithDefaultHitCounts() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testSwitchArrowNoDefaultNullBranch() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testSwitchYieldWithDefaultHitCounts() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testSwitchYieldNoDefaultNullBranch() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testSwitchVoidHitCounts() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testRecordGeneratedAndUserMethodHitCounts() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testSealedClassesDoNotCrash() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testEnhancedRangeHitCounts() { ... }
-
-    @GroovyVersionStart("4.0.0")
-    void testDecimalLiteralWithoutLeadingZero() { ... }
-}
-```
-
-**Running each test with and without `@CompileStatic`**: look at how `Groovy3CoverageRecordingTest`
-achieves this via the `TestSuite` and the constructor that accepts `specificName`. The suite likely
-calls each test method twice with different `groovyAllJar` / configuration. Replicate that pattern.
-
-### 3. Register in TestSuite
-
-Find `TestSuite.groovy` (or `.java`) in `clover-groovy/src/test/groovy/org/openclover/groovy/instr/`
-and add `Groovy4CoverageRecordingTest` the same way `Groovy3CoverageRecordingTest` was added.
-
-### 4. Potential Instrumentation Issues to Investigate
-
-**Issue A: Injected default branch with `[-1:-1..-1:-1]` source position**
-Switch expressions without an explicit `default` have a Groovyc-injected `EmptyStatement` singleton
-with coordinates `[-1:-1..-1:-1]`. Fix: inside `InstrumentingCodeVisitor.visitSwitch()`, detect
-`getDefaultStatement().getLineNumber() == -1` and synthesize a 1-character region at the closing `}`
-of the `SwitchStatement` using `(lastLineNumber, lastColumnNumber-1) .. (lastLineNumber, lastColumnNumber)`.
-Because `EmptyStatement$1` is a singleton and immutable, create a wrapper (e.g. a new `BlockStatement`
-or pass the synthesized coordinates directly to the recording call) rather than mutating it.
-
-**Issue B: Record auto-generated methods with `@CompileStatic`**
-Records automatically get `@CompileStatic` on all generated methods. Their bodies run through the
-CompileStatic instrumentation path. Check for NPE in `CloverAstTransformerInstructionSelection`
-when processing generated method bodies that may have unusual AST shapes.
-
-**Issue C: Switch expression variable scope balance**
-The compiler introduces a synthetic `__$$sev0` local. Verify that `pushVariableScope` /
-`popVariableScope` calls in `InstrumentingCodeVisitor` remain balanced when visiting the wrapping closure.
-
-**Issue D: Sealed class `@Sealed` annotation on interfaces**
-Verify that the `visitAnnotations()` no-op override in `InstrumentingCodeVisitor` correctly suppresses
-visiting annotation attribute expressions (the `permits` class list is stored there).
-
-### 5. Key Files to Read Before Starting
-
-```
-clover-groovy/src/main/java/org/openclover/groovy/instr/InstrumentingCodeVisitor.java
-clover-groovy/src/main/java/org/openclover/groovy/instr/OperatorsInstrumenter.java
-clover-groovy/src/main/java/org/openclover/groovy/instr/StatementInstrumenter.java
-clover-groovy/src/main/java/org/openclover/groovy/instr/CloverAstTransformerInstructionSelection.java
-clover-groovy/src/main/java/org/openclover/groovy/instr/GroovyUtils.java
-clover-groovy/src/test/groovy/org/openclover/groovy/instr/Groovy3CoverageRecordingTest.groovy
-clover-groovy/src/test/groovy/org/openclover/groovy/instr/TestBase.groovy
-```
-
-### 6. Key Design Decisions
-
-- No new AST node classes in Groovy 4 — no new visitor methods needed in `InstrumentingCodeVisitor`.
-- Switch expressions desugar to closures wrapping `SwitchStatement`; instrumentation flows through
-  existing closure and switch paths.
-- Record-generated methods are instrumented like any other method; they appear in coverage reports.
-  No exclusion mechanism is planned (impossible to distinguish user-overridden vs generated when both
-  share the same name and class annotation).
-- The Groovy 2 Class.forName compatibility strategy is **not needed** for Groovy 4 features.
-- Focus: write tests, run them, fix whatever breaks.
 
 ## Reference Commits
 

--- a/clover-groovy/src/main/java/org/openclover/groovy/instr/InstrumentingCodeVisitor.java
+++ b/clover-groovy/src/main/java/org/openclover/groovy/instr/InstrumentingCodeVisitor.java
@@ -29,6 +29,7 @@ import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.CaseStatement;
 import org.codehaus.groovy.ast.stmt.CatchStatement;
 import org.codehaus.groovy.ast.stmt.DoWhileStatement;
+import org.codehaus.groovy.ast.stmt.EmptyStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.ForStatement;
 import org.codehaus.groovy.ast.stmt.IfStatement;
@@ -541,8 +542,21 @@ public class InstrumentingCodeVisitor extends ClassCodeExpressionTransformer {
             caseStatement.visit(this);
         }
 
-        statement.getDefaultStatement().visit(this);
-        statement.setDefaultStatement(statementInstrumenter.instrumentBlockStatement(statement.getDefaultStatement()));
+        final Statement defaultStatement = statement.getDefaultStatement();
+        if (defaultStatement == EmptyStatement.INSTANCE) {
+            // Groovyc injects EmptyStatement.INSTANCE (shared singleton, coordinates [-1:-1..-1:-1])
+            // when a switch has no explicit default. Replace it with a MutableEmptyStatement at
+            // synthesized coordinates (the closing '}' of the SwitchStatement) so the fallthrough
+            // branch is registered in the coverage model.
+            final int synthLine = statement.getLastLineNumber();
+            final int synthCol = Math.max(1, statement.getLastColumnNumber() - 1);
+            final int synthEndCol = statement.getLastColumnNumber();
+            statement.setDefaultStatement(statementInstrumenter.instrumentBlockStatement(
+                    new MutableEmptyStatement(synthLine, synthCol, synthLine, synthEndCol)));
+        } else {
+            defaultStatement.visit(this);
+            statement.setDefaultStatement(statementInstrumenter.instrumentBlockStatement(defaultStatement));
+        }
     }
 
     @Override

--- a/clover-groovy/src/main/java/org/openclover/groovy/instr/MutableEmptyStatement.java
+++ b/clover-groovy/src/main/java/org/openclover/groovy/instr/MutableEmptyStatement.java
@@ -1,0 +1,24 @@
+package org.openclover.groovy.instr;
+
+import org.codehaus.groovy.ast.stmt.EmptyStatement;
+
+/**
+ * A non-singleton, mutable subclass of EmptyStatement used to represent synthetic default
+ * branches injected by Groovyc for switch expressions that lack an explicit default.
+ *
+ * The singleton EmptyStatement.INSTANCE has valid setters (inherited from ASTNode) but must
+ * not be mutated because it is shared across the AST. This subclass is created fresh for each
+ * injected default so that synthesized source coordinates can be assigned safely.
+ *
+ * Because this extends EmptyStatement, Groovy's own code-generation passes that check
+ * "x instanceof EmptyStatement" continue to work correctly.
+ */
+public class MutableEmptyStatement extends EmptyStatement {
+
+    public MutableEmptyStatement(int line, int col, int lastLine, int lastCol) {
+        setLineNumber(line);
+        setColumnNumber(col);
+        setLastLineNumber(lastLine);
+        setLastColumnNumber(lastCol);
+    }
+}

--- a/clover-groovy/src/main/java/org/openclover/groovy/instr/StatementInstrumenter.java
+++ b/clover-groovy/src/main/java/org/openclover/groovy/instr/StatementInstrumenter.java
@@ -64,6 +64,12 @@ public class StatementInstrumenter extends ClassInstumenter {
         if (maybeBlockStatement instanceof BlockStatement) {
             // method.getCode() usually returns BlockStatement
             return instrumentBlockStatement((BlockStatement)maybeBlockStatement, entryIncStatement);
+        } else if (maybeBlockStatement instanceof MutableEmptyStatement) {
+            // Synthesized default for a switch expression without an explicit default.
+            // Register it in the coverage model and return just the R.inc() call; the
+            // switch's null-return behaviour comes from the enclosing closure falling off the end.
+            final Statement instrStatement = instrumentStmt(maybeBlockStatement);
+            return instrStatement != null ? instrStatement : maybeBlockStatement;
         } else if (maybeBlockStatement instanceof TryCatchStatement
                 && entryIncStatement != null && currentVariableScope != null) {
             // Controllers in Grails have a TryCatchStatement instead of a BlockStatement in method.getCode()

--- a/clover-groovy/src/test/groovy/org/openclover/groovy/instr/Groovy4CoverageRecordingTest.groovy
+++ b/clover-groovy/src/test/groovy/org/openclover/groovy/instr/Groovy4CoverageRecordingTest.groovy
@@ -1,0 +1,388 @@
+package org.openclover.groovy.instr
+
+import groovy.transform.CompileStatic
+import org.openclover.buildutil.test.junit.GroovyVersionStart
+import org.openclover.core.CloverDatabase
+import org.openclover.core.CodeType
+import org.openclover.core.CoverageDataSpec
+import org.openclover.core.api.registry.MethodInfo
+import org.openclover.core.api.registry.PackageInfo
+import org.openclover.core.api.registry.StatementInfo
+import org.openclover.core.registry.entities.FullClassInfo
+import org.openclover.core.registry.entities.FullFileInfo
+
+/**
+ * Integration tests verifying Clover instrumentation of Groovy 4 language features.
+ *
+ * Groovy 4 key changes vs Groovy 3:
+ *   - Switch expressions (arrow and yield forms) compile to a ClosureExpression wrapping a SwitchStatement.
+ *   - Switch expressions without an explicit default get a Groovyc-injected EmptyStatement with
+ *     [-1:-1..-1:-1] coordinates; Clover synthesizes a 1-character region at the closing '}' so that
+ *     the fallthrough branch is recorded.
+ *   - Records compile to regular ClassNodes with auto-generated methods (toString, equals, hashCode, etc.).
+ *   - Sealed classes/interfaces use the @Sealed annotation; no new AST nodes.
+ *   - Enhanced range syntax and decimal literals without leading zero use the same AST nodes as before.
+ *
+ * Column positions in at(line, startCol, endLine, endCol) are 1-indexed; endCol is exclusive.
+ */
+@CompileStatic
+class Groovy4CoverageRecordingTest extends TestBase {
+
+    Groovy4CoverageRecordingTest(String testName) {
+        super(testName)
+    }
+
+    Groovy4CoverageRecordingTest(String methodName, String specificName,
+                                 File groovyAllJar, List<File> additionalGroovyJars) {
+        super(methodName, specificName, groovyAllJar, additionalGroovyJars)
+    }
+
+    // -----------------------------------------------------------------------
+    // Switch expression — arrow form with explicit default (value-returning)
+    //
+    // Compiled to: return { -> __$$sev0 = n; switch(__$$sev0) { ... } }.call()
+    // Closure called 3 times (for n=1, n=2, n=99).
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testSwitchArrowWithDefaultHitCounts() {
+        instrumentAndCompileWithGrover(["SwitchArrow.groovy": '''class SwitchArrow {
+    static String classify(int n) {
+        return switch (n) {
+            case 1 -> "one"
+            case 2 -> "two"
+            default -> "other"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(2) == "two"
+        assert classify(99) == "other"
+    }
+}'''])
+        runWithAsserts("SwitchArrow")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("SwitchArrow.groovy"), { FullFileInfo f ->
+                        assertClass f, named("SwitchArrow"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
+                                m.hitCount == 3
+                            }) &&
+                            assertMethod(c, simplyNamed("main"), { MethodInfo m ->
+                                m.hitCount == 1
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Switch expression — arrow form without default (null fallthrough)
+    //
+    // Groovyc injects a synthetic EmptyStatement with [-1:-1..-1:-1] for the missing default.
+    // After the fix in visitSwitch(), a 1-char synthesized region is created at the closing '}'
+    // of the SwitchStatement (line 6, col 9 exclusive-end 10) and registered in the model.
+    //
+    // classify(1)  → case-1 branch, default NOT hit
+    // classify(99) → no case matches, injected null-default IS hit
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testSwitchArrowNoDefaultNullBranch() {
+        instrumentAndCompileWithGrover(["SwitchArrowNoDefault.groovy": '''class SwitchArrowNoDefault {
+    static String classify(int n) {
+        return switch (n) {
+            case 1 -> "one"
+            case 2 -> "two"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(99) == null
+    }
+}'''])
+        runWithAsserts("SwitchArrowNoDefault")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("SwitchArrowNoDefault.groovy"), { FullFileInfo f ->
+                        assertClass f, named("SwitchArrowNoDefault"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
+                                // classify called twice; the synthesized default (injected null branch)
+                                // appears at the closing '}' of the switch (line 6, col 9..10) with hit=1
+                                m.hitCount == 2 &&
+                                assertStatement(m, at(6, 9, 6, 10), hits(1))
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Switch expression — yield form with explicit default (value-returning)
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testSwitchYieldWithDefaultHitCounts() {
+        instrumentAndCompileWithGrover(["SwitchYield.groovy": '''class SwitchYield {
+    static String classify(int n) {
+        return switch (n) {
+            case 1: yield "one"
+            case 2: yield "two"
+            default: yield "other"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(99) == "other"
+    }
+}'''])
+        runWithAsserts("SwitchYield")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("SwitchYield.groovy"), { FullFileInfo f ->
+                        assertClass f, named("SwitchYield"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
+                                m.hitCount == 2
+                            }) &&
+                            assertMethod(c, simplyNamed("main"), { MethodInfo m ->
+                                m.hitCount == 1
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Switch expression — yield form without default (null fallthrough)
+    //
+    // Same injected-null-default issue as the arrow-no-default case.
+    // classify(1)  → case-1 hit; classify(99) → injected default hit.
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testSwitchYieldNoDefaultNullBranch() {
+        instrumentAndCompileWithGrover(["SwitchYieldNoDefault.groovy": '''class SwitchYieldNoDefault {
+    static String classify(int n) {
+        return switch (n) {
+            case 1: yield "one"
+            case 2: yield "two"
+        }
+    }
+    static void main(String[] args) {
+        assert classify(1) == "one"
+        assert classify(99) == null
+    }
+}'''])
+        runWithAsserts("SwitchYieldNoDefault")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("SwitchYieldNoDefault.groovy"), { FullFileInfo f ->
+                        assertClass f, named("SwitchYieldNoDefault"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
+                                m.hitCount == 2 &&
+                                assertStatement(m, at(6, 9, 6, 10), hits(1))
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Switch expression — void/side-effect cases (no returned value)
+    //
+    // Void switch still compiles to a closure call (ExpressionStatement rather than
+    // ReturnStatement wrapping the call). The injected null-default is still present
+    // when there is no explicit default.
+    //
+    // classify(1)  → case-1 side effect; classify(99) → injected default hit.
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testSwitchVoidHitCounts() {
+        instrumentAndCompileWithGrover(["SwitchVoid.groovy": '''class SwitchVoid {
+    static List<String> log = []
+    static void classify(int n) {
+        switch (n) {
+            case 1 -> log.add("one")
+            case 2 -> log.add("two")
+        }
+    }
+    static void main(String[] args) {
+        classify(1)
+        classify(99)
+        assert log == ["one"]
+    }
+}'''])
+        runWithAsserts("SwitchVoid")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("SwitchVoid.groovy"), { FullFileInfo f ->
+                        assertClass f, named("SwitchVoid"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
+                                // classify called twice; injected default is at closing '}' of switch
+                                // (line 7 in the source, col 9..10)
+                                m.hitCount == 2 &&
+                                assertStatement(m, at(7, 9, 7, 10), hits(1))
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Record — auto-generated and user-defined methods
+    //
+    // Records compile to a ClassNode with @RecordBase, @TupleConstructor etc.
+    // Auto-generated methods (toString, equals, hashCode, …) are NOT flagged synthetic,
+    // so Clover instruments them. User-defined methods are instrumented normally.
+    // Test verifies no crash during instrumentation and that user-defined origin() is hit.
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testRecordGeneratedAndUserMethodHitCounts() {
+        instrumentAndCompileWithGrover(["Point.groovy": '''record Point(int x, int y) {
+    static Point origin() { new Point(0, 0) }
+    static void main(String[] args) {
+        def p = new Point(3, 4)
+        assert p.x() == 3
+        assert p.y() == 4
+        assert p.toString() != null
+        def o = origin()
+        assert o.x() == 0
+    }
+}'''])
+        runWithAsserts("Point")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("Point.groovy"), { FullFileInfo f ->
+                        assertClass f, named("Point"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("origin"), { MethodInfo m ->
+                                m.hitCount == 1
+                            }) &&
+                            assertMethod(c, simplyNamed("main"), { MethodInfo m ->
+                                m.hitCount == 1
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Sealed classes — verification that instrumentation does not crash
+    //
+    // sealed interface Shape permits Circle, Square {} compiles to a ClassNode
+    // annotated with @groovy.transform.Sealed. No new expression/statement nodes;
+    // just verify that Clover processes the code without throwing an exception.
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testSealedClassesDoNotCrash() {
+        instrumentAndCompileWithGrover(["SealedShape.groovy": '''sealed interface Shape permits Circle, Square {}
+final class Circle implements Shape {
+    final float radius
+    Circle(float r) { this.radius = r }
+}
+final class Square implements Shape {
+    final float side
+    Square(float s) { this.side = s }
+}
+class SealedTest {
+    static String name(Shape s) {
+        if (s instanceof Circle) return "circle"
+        if (s instanceof Square) return "square"
+        return "unknown"
+    }
+    static void main(String[] args) {
+        assert name(new Circle(1.0f)) == "circle"
+        assert name(new Square(1.0f)) == "square"
+    }
+}'''])
+        runWithAsserts("SealedTest")
+    }
+
+    // -----------------------------------------------------------------------
+    // Enhanced range syntax — left-open (<..) and both-open (<..<)
+    //
+    // Parses to RangeExpression nodes (same class as before) with exclusiveLeft/
+    // exclusiveRight flags. No instrumentation changes needed; verify no crash and
+    // correct method hit counts.
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testEnhancedRangeHitCounts() {
+        instrumentAndCompileWithGrover(["RangeTest.groovy": '''class RangeTest {
+    static List<Integer> leftOpen(int from, int to) {
+        return (from<..to).toList()
+    }
+    static List<Integer> bothOpen(int from, int to) {
+        return (from<..<to).toList()
+    }
+    static void main(String[] args) {
+        assert leftOpen(0, 3) == [1, 2, 3]
+        assert bothOpen(0, 3) == [1, 2]
+    }
+}'''])
+        runWithAsserts("RangeTest")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("RangeTest.groovy"), { FullFileInfo f ->
+                        assertClass f, named("RangeTest"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("leftOpen"), { MethodInfo m ->
+                                m.hitCount == 1
+                            }) &&
+                            assertMethod(c, simplyNamed("bothOpen"), { MethodInfo m ->
+                                m.hitCount == 1
+                            })
+                        }
+                    }
+                })
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal literal without leading zero (.5 == 0.5)
+    //
+    // Parses to a ConstantExpression (same as before). No instrumentation changes
+    // needed; verify no crash and correct method hit counts.
+    // -----------------------------------------------------------------------
+    @GroovyVersionStart("4.0.0")
+    void testDecimalLiteralWithoutLeadingZero() {
+        instrumentAndCompileWithGrover(["DecimalLiteralTest.groovy": '''class DecimalLiteralTest {
+    static double half() { .5 }
+    static double quarter() { .25 }
+    static void main(String[] args) {
+        assert half() == 0.5
+        assert quarter() == 0.25
+    }
+}'''])
+        runWithAsserts("DecimalLiteralTest")
+
+        assertPackage(
+                CloverDatabase.loadWithCoverage(db.absolutePath, new CoverageDataSpec()).getModel(CodeType.APPLICATION),
+                isDefaultPackage,
+                { PackageInfo p ->
+                    assertFile p, named("DecimalLiteralTest.groovy"), { FullFileInfo f ->
+                        assertClass f, named("DecimalLiteralTest"), { FullClassInfo c ->
+                            assertMethod(c, simplyNamed("half"), { MethodInfo m ->
+                                m.hitCount == 1
+                            }) &&
+                            assertMethod(c, simplyNamed("quarter"), { MethodInfo m ->
+                                m.hitCount == 1
+                            })
+                        }
+                    }
+                })
+    }
+}

--- a/clover-groovy/src/test/groovy/org/openclover/groovy/instr/Groovy4CoverageRecordingTest.groovy
+++ b/clover-groovy/src/test/groovy/org/openclover/groovy/instr/Groovy4CoverageRecordingTest.groovy
@@ -68,10 +68,10 @@ class Groovy4CoverageRecordingTest extends TestBase {
                     assertFile p, named("SwitchArrow.groovy"), { FullFileInfo f ->
                         assertClass f, named("SwitchArrow"), { FullClassInfo c ->
                             assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
-                                m.hitCount == 3
-                            }) &&
-                            assertMethod(c, simplyNamed("main"), { MethodInfo m ->
-                                m.hitCount == 1
+                                m.hitCount == 3 &&
+                                assertStatement(m, at(4, 23, 4, 28), hits(1)) &&
+                                assertStatement(m, at(5, 23, 5, 28), hits(1)) &&
+                                assertStatement(m, at(6, 24, 6, 31), hits(1))
                             })
                         }
                     }
@@ -114,6 +114,8 @@ class Groovy4CoverageRecordingTest extends TestBase {
                                 // classify called twice; the synthesized default (injected null branch)
                                 // appears at the closing '}' of the switch (line 6, col 9..10) with hit=1
                                 m.hitCount == 2 &&
+                                assertStatement(m, at(4, 23, 4, 28), hits(1)) &&
+                                assertStatement(m, at(5, 23, 5, 28), hits(0)) &&
                                 assertStatement(m, at(6, 9, 6, 10), hits(1))
                             })
                         }
@@ -148,10 +150,10 @@ class Groovy4CoverageRecordingTest extends TestBase {
                     assertFile p, named("SwitchYield.groovy"), { FullFileInfo f ->
                         assertClass f, named("SwitchYield"), { FullClassInfo c ->
                             assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
-                                m.hitCount == 2
-                            }) &&
-                            assertMethod(c, simplyNamed("main"), { MethodInfo m ->
-                                m.hitCount == 1
+                                m.hitCount == 2 &&
+                                assertStatement(m, at(4, 21, 4, 32), hits(1)) &&
+                                assertStatement(m, at(5, 21, 5, 32), hits(0)) &&
+                                assertStatement(m, at(6, 22, 6, 35), hits(1))
                             })
                         }
                     }
@@ -188,6 +190,8 @@ class Groovy4CoverageRecordingTest extends TestBase {
                         assertClass f, named("SwitchYieldNoDefault"), { FullClassInfo c ->
                             assertMethod(c, simplyNamed("classify"), { MethodInfo m ->
                                 m.hitCount == 2 &&
+                                assertStatement(m, at(4, 21, 4, 32), hits(1)) &&
+                                assertStatement(m, at(5, 21, 5, 32), hits(0)) &&
                                 assertStatement(m, at(6, 9, 6, 10), hits(1))
                             })
                         }
@@ -232,6 +236,8 @@ class Groovy4CoverageRecordingTest extends TestBase {
                                 // classify called twice; injected default is at closing '}' of switch
                                 // (line 7 in the source, col 9..10)
                                 m.hitCount == 2 &&
+                                assertStatement(m, at(5, 23, 5, 37), hits(1)) &&
+                                assertStatement(m, at(6, 23, 6, 37), hits(0)) &&
                                 assertStatement(m, at(7, 9, 7, 10), hits(1))
                             })
                         }
@@ -269,10 +275,8 @@ class Groovy4CoverageRecordingTest extends TestBase {
                     assertFile p, named("Point.groovy"), { FullFileInfo f ->
                         assertClass f, named("Point"), { FullClassInfo c ->
                             assertMethod(c, simplyNamed("origin"), { MethodInfo m ->
-                                m.hitCount == 1
-                            }) &&
-                            assertMethod(c, simplyNamed("main"), { MethodInfo m ->
-                                m.hitCount == 1
+                                m.hitCount == 1 &&
+                                assertStatement(m, at(2, 29, 2, 44), hits(1))
                             })
                         }
                     }
@@ -341,10 +345,12 @@ class SealedTest {
                     assertFile p, named("RangeTest.groovy"), { FullFileInfo f ->
                         assertClass f, named("RangeTest"), { FullClassInfo c ->
                             assertMethod(c, simplyNamed("leftOpen"), { MethodInfo m ->
-                                m.hitCount == 1
+                                m.hitCount == 1 &&
+                                assertStatement(m, at(3, 9, 3, 36), hits(1))
                             }) &&
                             assertMethod(c, simplyNamed("bothOpen"), { MethodInfo m ->
-                                m.hitCount == 1
+                                m.hitCount == 1 &&
+                                assertStatement(m, at(6, 9, 6, 37), hits(1))
                             })
                         }
                     }

--- a/clover-groovy/src/test/groovy/org/openclover/groovy/instr/GroovyCoverageTest.groovy
+++ b/clover-groovy/src/test/groovy/org/openclover/groovy/instr/GroovyCoverageTest.groovy
@@ -378,18 +378,20 @@ class GroovyCoverageTest extends TestBase {
                         assertClass f, named("Foo"), { FullClassInfo c ->
                             assertMethod(c, simplyNamed("implicitReturns"), { MethodInfo m ->
                                 m.hitCount == 2 &&
-                                        m.statements.size() == 3 &&
+                                        m.statements.size() == 4 &&
                                         assertStatement(m, at(4, 29, 11, 30), hits(2)) &&    // entire switch block
                                         assertStatement(m, at(6, 37, 6, 52), hits(1)) &&     // new Integer(10)
-                                        assertStatement(m, at(9, 37, 9, 54), hits(1))        // new String("abc")
+                                        assertStatement(m, at(9, 37, 9, 54), hits(1)) &&     // new String("abc")
+                                        assertStatement(m, at(11, 29, 11, 30), hits(0))      // synthesized default (no explicit default → injected EmptyStatement)
                             }) &&
 
                                     assertMethod(c, simplyNamed("explicitReturns"), { MethodInfo m ->
                                         m.hitCount == 2 &&
-                                                m.statements.size() == 3 &&
+                                                m.statements.size() == 4 &&
                                                 assertStatement(m, at(15, 29, 20, 30), hits(2)) &&     // entire switch block
                                                 assertStatement(m, at(17, 37, 17, 59), hits(1)) &&     // case true, return new Integer(10)
-                                                assertStatement(m, at(19, 37, 19, 61), hits(1))        // case false, return new String("abc")
+                                                assertStatement(m, at(19, 37, 19, 61), hits(1)) &&     // case false, return new String("abc")
+                                                assertStatement(m, at(20, 29, 20, 30), hits(0))        // synthesized default (no explicit default → injected EmptyStatement)
                                     })
                         }
                     }

--- a/clover-groovy/src/test/groovy/org/openclover/groovy/instr/TestSuite.groovy
+++ b/clover-groovy/src/test/groovy/org/openclover/groovy/instr/TestSuite.groovy
@@ -19,6 +19,7 @@ class TestSuite
             (GroovyArraysTest)             : DefaultTestSelector.instance.closure,
             (Groovy2CoverageRecordingTest) : DefaultTestSelector.instance.closure,
             (Groovy3CoverageRecordingTest) : DefaultTestSelector.instance.closure,
+            (Groovy4CoverageRecordingTest) : DefaultTestSelector.instance.closure,
             (GroovyCoverageTest)           : DefaultTestSelector.instance.closure,
             (GroovyElvisOperatorTest)      : DefaultTestSelector.instance.closure,
             (GroovyLambdasTest)            : DefaultTestSelector.instance.closure,


### PR DESCRIPTION
Instrumentation of new switch statements, including the synthetic 'default' branch, if not specified in the code, returning null.

Introduced MutableEmptyStatement to be able to correctly set location of such statements (null branch in a switch, implicit returns)

Testing enhanced range syntax, sealed classes, auto-generated methods for records, decimal literals.