### PR TITLE
OC-270: an additional test case for the parameterized record

### DIFF
--- a/clover-core/src/test/groovy/org/openclover/core/JavaSyntax16CompilationTest.groovy
+++ b/clover-core/src/test/groovy/org/openclover/core/JavaSyntax16CompilationTest.groovy
@@ -41,6 +41,9 @@ class JavaSyntax16CompilationTest extends JavaSyntaxCompilationTestBase {
         // Record4 method is instrumented
         assertFileMatches(fileName, R_INC + "return input\\.toString\\(\\);", false)
 
+        // Record5 compact constructor (with a parameterized/generic type parameter bound) is instrumented
+        assertFileMatches(fileName, "Record5 \\{" + R_INC, false)
+
         // RecordIsNotAReservedKeyword method with 'record' as symbols is instrumented
         assertFileMatches(fileName, R_INC + "this\\.record = record;", false)
         assertFileMatches(fileName, R_INC + "System\\.out\\.println\\(record\\);", false)

--- a/clover-core/src/test/groovy/org/openclover/core/instr/java/ParseGenericsTest.groovy
+++ b/clover-core/src/test/groovy/org/openclover/core/instr/java/ParseGenericsTest.groovy
@@ -40,6 +40,17 @@ class ParseGenericsTest {
         assertSourceOkay("GenericsTestcase-2_2.java.txt")
     }
 
+    @Test
+    void testRecordWithParameterizedTypeParameterBound() throws Exception {
+        // type parameter bound itself being a parameterized (generic) type, e.g. Key<?>
+        checkParsing([
+            "interface Key<K> {}",
+            "interface Keyed<T> { T key(); }",
+            "record DefaultKeyResult<T extends Key<?>>(T key) implements Keyed<T> { " +
+                "DefaultKeyResult { java.util.Objects.requireNonNull(key); } }"
+        ] as String[])
+    }
+
     static class TestInstrumentationSource implements InstrumentationSource {
         private File sourceFile
         private File mTestcasesSrcDir

--- a/clover-core/src/test/resources/javasyntax16/Java16RecordClass.java
+++ b/clover-core/src/test/resources/javasyntax16/Java16RecordClass.java
@@ -43,6 +43,17 @@ record Record4<I extends Number>(I input) {
     }
 }
 
+/** A generic record whose type parameter has a parameterized (generic) bound, see OC-270 */
+interface Key<K> {}
+interface Keyed<T> {
+    T key();
+}
+record Record5<T extends Key<?>>(T key) implements Keyed<T> {
+    Record5 {
+        java.util.Objects.requireNonNull(key, "Key cannot be null.");
+    }
+}
+
 /** Despite introducing records in Java16, you can still use it for symbols, sic! */
 class RecordIsNotAReservedKeyword {
     int record = 0;


### PR DESCRIPTION
with a type bound; the problem itself have been already fixed in OC-251 (commit 3847553d).