### PR TITLE
OC-273: handle switch statements with comma-separated case labels

### DIFF
--- a/clover-core/src/main/java/org/openclover/core/instr/java/java.g
+++ b/clover-core/src/main/java/org/openclover/core/instr/java/java.g
@@ -2538,7 +2538,7 @@ statement [CloverToken owningLabel] returns [CloverToken last]
         SEMI!
     |
         // a classic switch/case with colons
-        ( SWITCH LPAREN expression RPAREN LCURLY (CASE expression | DEFAULT) COLON) =>
+        ( SWITCH LPAREN expression RPAREN LCURLY (CASE constantExpression (COMMA constantExpression)* | DEFAULT) COLON) =>
         contextAndComplexity = colonSwitchExpression[owningLabel, false]
         {
             saveContext = contextAndComplexity.getContext();

--- a/clover-core/src/test/groovy/org/openclover/core/JavaSyntax14CompilationTest.groovy
+++ b/clover-core/src/test/groovy/org/openclover/core/JavaSyntax14CompilationTest.groovy
@@ -102,8 +102,10 @@ class JavaSyntax14CompilationTest extends JavaSyntaxCompilationTestBase {
         // this is a regression test, using break in switch statements must be allowed
         assertFileMatches(fileName, R_INC + quote("k++;") + R_INC + quote("break;"))
         assertFileMatches(fileName, quote("default:") + ".*" + R_INC + quote("break;"))
-    }
 
+        // comma-separated case labels combined with the old colon syntax
+        assertFileMatches(fileName, quote("case A, B, C, D:") + "[\\s\\S]*" + R_INC + quote("a = true;"))
+    }
 
     @Test
     void switchExpressionWithCaseAndDefaultCanUseLambdasReturningValues() {

--- a/clover-core/src/test/resources/javasyntax14/Java14SwitchStatementWithCaseColon.java
+++ b/clover-core/src/test/resources/javasyntax14/Java14SwitchStatementWithCaseColon.java
@@ -8,4 +8,19 @@ public class Java14SwitchStatementWithCaseColon {
             default:break;
         }
     }
+
+    enum Values {
+        A, B, C, D, Hello
+    }
+
+    // comma-separated case labels combined with the old colon syntax
+    static boolean multiCaseWithColon(Values u) {
+        boolean a = false;
+        switch (u) {
+            case A, B, C, D:
+                a = true;
+                break;
+        }
+        return a;
+    }
 }


### PR DESCRIPTION
OC-273: handle switch statements with comma-separated case labels combined with the old colon syntax