### PR TITLE
OC-249 constructor instrumentation

### DIFF
--- a/.claude/memory/test-class-constructor-instrumentation.md
+++ b/.claude/memory/test-class-constructor-instrumentation.md
@@ -1,0 +1,105 @@
+OC-249: Constructors incorrectly instrumented as test methods
+
+Context
+
+GitHub issue #249: when a class in a test source set has a
+constructor (reported for a static inner class inside a test class), OpenClover can treat that constructor as a
+test method and apply per-test rewriting. The rewrite moves the constructor body into a synthetic private
+helper method, so super(...) / this(...) ends up inside the helper rather than the constructor, and the
+renamed signature loses its constructor-ness — the instrumented source no longer compiles.
+
+The issue's suggested workaround is to narrow the test patterns (@Test-only, test*-only, top-level .*Test
+classes), which confirms the trigger: it is the user-configured test spec, not the built-in heuristic.
+
+Root cause
+
+Constructors are parsed by standardConstructorSignature / compactConstructorSignature in
+clover-core/src/main/java/org/openclover/core/instr/java/java.g (~lines 1255, 1288), which build a
+MethodSignature with a null returnType — that null is the codebase's existing marker for "not a real
+method". constructorBody (java.g ~1923) then calls the same instrEnterMethod helper as ordinary methods, so a
+constructor gets a MethodRegistrationNode and a MethodEntryInstrEmitter just like a method does.
+
+DefaultTestDetector.isMethodMatch already guards against this — clover-core/.../instr/tests/DefaultTestDetector.java:53
+has && signature.getReturnType() != null with the comment // no ctors.
+
+TestSpec.isMethodMatch has no such guard (clover-core/.../instr/tests/TestSpec.java:103-110). It only
+checks name / annotation / return-type / tag patterns, and methodReturnPatternMatches(null) returns true
+whenever no return-type pattern is configured. So any user test spec matching by class pattern plus a permissive
+method pattern also matches every constructor in that class. The match then reaches
+MethodRegistrationNode.init (clover-core/.../instr/java/MethodRegistrationNode.java:62-66), where
+addTestRewriteInstr = isInstrEnabled() && cfg.isRecordTestResults() && isTestMethod triggers the broken rewrite
+(it emits signature.getRenamedNormalisedSignature(syntheticTestName) and delegates the body).
+
+Approach
+
+Two changes — fix the root cause, plus a guard so no TestDetector implementation (including the Eclipse plugin's
+and user-supplied ones) can trigger the broken rewrite again.
+
+1. Add an explicit constructor marker on MethodSignature
+
+clover-core/src/main/java/org/openclover/core/registry/entities/MethodSignature.java
+
+Add a small accessor documenting the existing convention rather than sprinkling getReturnType() != null checks:
+
+/** Constructors and initializers are parsed with a null return type. */
+public boolean isConstructorLike() {
+    return returnType == null;
+}
+
+Note: instance/static initializers (java.g:1869, 1880) also carry a null returnType; they are already
+non-renameable (normSeqPrefix == null), so the shared name is accurate. Keep the check field-based — do not
+change how the grammar builds signatures, and do not touch write/read, which are not exercised for ctors.
+
+2. Exclude constructors from test matching in TestSpec
+
+clover-core/src/main/java/org/openclover/core/instr/tests/TestSpec.java — in isMethodMatch, mirror the
+DefaultTestDetector guard:
+
+final MethodSignature signature = methodContext.getSignature();
+return !signature.isConstructorLike()      // no ctors — see OC-249
+        && methodMatches(signature.getName())
+        && ...;
+
+Also switch DefaultTestDetector.java:53 to the new accessor so the convention lives in one place.
+
+3. Guard the Java instrumenter (defence in depth)
+
+Both Java call sites compute isTestMethod independently and must agree:
+
+- MethodRegistrationNode.init (line 62) — state.isDetectTests() && !signature.isConstructorLike() && state.getTestDetector().isMethodMatch(...)
+- MethodEntryInstrEmitter.init (line 29-32) — same additional condition
+
+This makes the broken rewrite unreachable for constructors regardless of the detector in use. The Groovy path
+(InstrumentingCodeVisitor:308) visits ConstructorNode separately and is out of scope.
+
+Files to change
+
+- clover-core/src/main/java/org/openclover/core/registry/entities/MethodSignature.java
+- clover-core/src/main/java/org/openclover/core/instr/tests/TestSpec.java
+- clover-core/src/main/java/org/openclover/core/instr/tests/DefaultTestDetector.java
+- clover-core/src/main/java/org/openclover/core/instr/java/MethodRegistrationNode.java
+- clover-core/src/main/java/org/openclover/core/instr/java/MethodEntryInstrEmitter.java
+- CHANGELOG.md — add under ### Fixed: Issue #249: Constructors in test classes were instrumented as test methods, producing uncompilable code.
+
+Tests
+
+- clover-core/src/test/groovy/org/openclover/core/instr/tests/TestSpecTest.groovy — add a case: a TestSpec
+with a permissive method pattern (e.g. .*) and no return-type pattern must not match a constructor
+signature (new MethodSignature(..., "MyInnerClass", null, null, params, null)), but must still match a normal
+method. Follow the existing spec.isMethodMatch(null, JavaMethodContext.createFor(sig)) style.
+- clover-core/src/test/groovy/org/openclover/core/instr/java/InstrumentationTestMethodsTest.groovy — add a
+regression case reproducing the issue: source with a test class containing a static inner class whose
+constructor calls super(), instrumented with recordTestResults enabled and a TestSpec-based detector.
+Assert the constructor keeps its own body (plain RECORDER.R.inc(n); after the super() call, per the
+constructorBody skip-token behaviour) and that no synthetic renamed method is emitted. Use the
+checkInstrumentation(String[][], JavaInstrumentationConfig) overload from InstrumentationTestBase.groovy:81
+so the custom detector can be configured.
+
+Verification
+
+1. mvn -pl clover-core test -Dtest='TestSpecTest,DefaultTestDetectorTest,InstrumentationTestMethodsTest,InstrumentationDetectionTest'
+— new cases pass, existing ones unchanged.
+2. Full mvn -pl clover-core test to catch golden-string regressions in the other Instrumentation*Test classes.
+3. End-to-end: take the issue's reproducer (test class with a static inner class whose ctor calls super()), run
+CloverInstr over it with a permissive -tsm/test-spec configuration and recordTestResults on, then
+javac the instrumented output — it must compile. Before the fix it fails; after, it compiles.

--- a/.claude/memory/test-class-constructor-instrumentation.md
+++ b/.claude/memory/test-class-constructor-instrumentation.md
@@ -66,7 +66,7 @@ Also switch DefaultTestDetector.java:53 to the new accessor so the convention li
 
 Both Java call sites compute isTestMethod independently and must agree:
 
-- MethodRegistrationNode.init (line 62) — state.isDetectTests() && !signature.isConstructorLike() && state.getTestDetector().isMethodMatch(...)
+- MethodRegistrationNode.init (line 62) — state.isDetectTests() && !signature.isConstructorLike() && state.getTestDetector().isMethodMatch(...)
 - MethodEntryInstrEmitter.init (line 29-32) — same additional condition
 
 This makes the broken rewrite unreachable for constructors regardless of the detector in use. The Groovy path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 5.0.1]
+
+- Issue #249: Constructors in test classes were instrumented as test methods, producing uncompilable code.
+
 ## [Unreleased 4.5.0]
 
 ### Added

--- a/clover-core/src/main/java/org/openclover/core/instr/java/MethodEntryInstrEmitter.java
+++ b/clover-core/src/main/java/org/openclover/core/instr/java/MethodEntryInstrEmitter.java
@@ -11,7 +11,7 @@ import static org.openclover.runtime.instr.Bindings.$CoverageRecorder$globalSlic
 import static org.openclover.runtime.instr.Bindings.$CoverageRecorder$inc;
 
 public class MethodEntryInstrEmitter extends Emitter {
-    private MethodRegistrationNode methodNode;
+    private final MethodRegistrationNode methodNode;
     private boolean addTestInstr;
     private boolean needsFinally = false;
 
@@ -29,6 +29,7 @@ public class MethodEntryInstrEmitter extends Emitter {
         addTestInstr =
             !state.getCfg().isRecordTestResults() // if recording test results, we need to rewrite the tests which occurs external to the method
                 && state.isDetectTests()
+                && !methodNode.getSignature().isConstructorLike()
                 && state.getTestDetector().isMethodMatch(state, JavaMethodContext.createFor(methodNode.getSignature()));
         StringBuilder instr = new StringBuilder();
 

--- a/clover-core/src/main/java/org/openclover/core/instr/java/MethodRegistrationNode.java
+++ b/clover-core/src/main/java/org/openclover/core/instr/java/MethodRegistrationNode.java
@@ -59,7 +59,9 @@ public class MethodRegistrationNode extends Emitter {
     @Override
     public void init(InstrumentationState state) {
         final JavaInstrumentationConfig cfg = state.getCfg();
-        final boolean isTestMethod = state.isDetectTests() && state.getTestDetector().isMethodMatch(state, JavaMethodContext.createFor(signature));
+        final boolean isTestMethod = state.isDetectTests()
+                && !signature.isConstructorLike()
+                && state.getTestDetector().isMethodMatch(state, JavaMethodContext.createFor(signature));
         final String javaLangPrefix = cfg.getJavaLangPrefix();
 
         boolean addTestRewriteInstr = state.isInstrEnabled() && cfg.isRecordTestResults() && isTestMethod;

--- a/clover-core/src/main/java/org/openclover/core/instr/tests/DefaultTestDetector.java
+++ b/clover-core/src/main/java/org/openclover/core/instr/tests/DefaultTestDetector.java
@@ -45,13 +45,13 @@ public class DefaultTestDetector implements TestDetector {
     @Override
     public boolean isMethodMatch(SourceContext sourceContext, MethodContext methodContext) {
         final MethodSignature signature = methodContext.getSignature();
-        if (methodContext != null
+        if (signature != null
                 //Concrete methods
                 && !Modifier.isAbstract(signature.getBaseModifiersMask())
                 //TestNG/JUnit5 require at least non private. i.e. public, package private, protected are okay.
                 && !Modifier.isPrivate(signature.getBaseModifiersMask())
                 // no ctors
-                && signature.getReturnType() != null) {
+                && !signature.isConstructorLike()) {
 
             // annotations or tags trump other heuristics
             if ( (sourceContext.areAnnotationsSupported() && hasTestAnnotations(signature.getModifiers()))

--- a/clover-core/src/main/java/org/openclover/core/instr/tests/TestSpec.java
+++ b/clover-core/src/main/java/org/openclover/core/instr/tests/TestSpec.java
@@ -103,7 +103,8 @@ public class TestSpec implements TestDetector {
     @Override
     public boolean isMethodMatch(SourceContext sourceContext, MethodContext methodContext) {
         final MethodSignature signature = methodContext.getSignature();
-        return methodMatches(signature.getName()) &&
+        return !signature.isConstructorLike() && // constructors can't be treated as test methods — see OC-249
+                methodMatches(signature.getName()) &&
                 methodAnnotationMatches(signature.getModifiers()) &&
                 methodReturnPatternMatches(signature.getReturnType()) &&
                 methodTagMatches(signature.getTags());

--- a/clover-core/src/main/java/org/openclover/core/registry/entities/MethodSignature.java
+++ b/clover-core/src/main/java/org/openclover/core/registry/entities/MethodSignature.java
@@ -125,6 +125,14 @@ public class MethodSignature implements TaggedPersistent, MethodSignatureInfo {
         return returnType;
     }
 
+    /**
+     * Is method a constructor or an initializer.
+     */
+    public boolean isConstructorLike() {
+        // constructors and initializers have a null return type
+        return returnType == null;
+    }
+
     @Override
     public String getTypeParams() {
         return typeParams;

--- a/clover-core/src/test/groovy/org/openclover/core/instr/java/InstrumentationTestMethodsTest.groovy
+++ b/clover-core/src/test/groovy/org/openclover/core/instr/java/InstrumentationTestMethodsTest.groovy
@@ -1,7 +1,14 @@
 package org.openclover.core.instr.java
 
 import org.junit.Test
+import org.openclover.core.cfg.instr.java.JavaInstrumentationConfig
+import org.openclover.core.instr.tests.TestSpec
 import org.openclover.runtime.CloverNames
+
+import java.util.regex.Pattern
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
 
 class InstrumentationTestMethodsTest extends InstrumentationTestBase {
 
@@ -90,5 +97,30 @@ class InstrumentationTestMethodsTest extends InstrumentationTestBase {
                 [ "public class MyTestP { @Test(expected=Foo.class) public void foo() throws Foo, Bar {} }",
                   "public class MyTestP {$testClassField$snifferField @Test(expected=Foo.class) public void foo() throws Foo, Bar {RECORDER.R.globalSliceStart(getClass().getName(),0);int " + CloverNames.namespace("p") + "=0;java.lang.Throwable " + CloverNames.namespace("t") + "=null;try{RECORDER();"+ CloverNames.namespace("p")+"=0;"+ CloverNames.namespace("t")+"=new java.lang.RuntimeException(new String(new char[] {69,120,112,101,99,116,101,100,32,111,110,101,32,111,102,32,116,104,101,32,102,111,108,108,111,119,105,110,103,32,101,120,99,101,112,116,105,111,110,115,32,116,111,32,98,101,32,116,104,114,111,119,110,32,102,114,111,109,32,116,101,115,116,32,109,101,116,104,111,100,32,102,111,111,58,32,91,70,111,111,93,}));}catch(java.lang.Throwable "+ CloverNames.namespace("t2")+"){if("+ CloverNames.namespace("t2")+" instanceof Foo){"+ CloverNames.namespace("p")+"=1;" + CloverNames.namespace("t") + "=null;}else{"+ CloverNames.namespace("p")+"=0;"+ CloverNames.namespace("t")+"="+ CloverNames.namespace("t2")+";}if("+ CloverNames.namespace("p")+"==0&&"+ CloverNames.namespace("t")+"==null){"+ CloverNames.namespace("t")+"="+ CloverNames.namespace("t2")+";}RECORDER.R.rethrow("+ CloverNames.namespace("t2")+");}finally{RECORDER.R.globalSliceEnd(getClass().getName(),\"MyTestP.foo\",SNIFFER.getTestName(),0,"+ CloverNames.namespace("p")+","+ CloverNames.namespace("t")+");}}private void  RECORDER() throws Foo, Bar{RECORDER.R.inc(0);} }" ],
         ] as String[][])
+    }
+
+    /**
+     * A constructor must never be treated as a test method and rewritten,
+     * even when a user-supplied {@link TestSpec} has a permissive method pattern. Rewriting a
+     * constructor would move its {@code super(...)} call into a synthetic helper method, producing
+     * source that does not compile.
+     */
+    @Test
+    void testConstructorNotRewrittenAsTestMethod() throws Exception {
+        JavaInstrumentationConfig config = getInstrConfig(newDbTempFile().getAbsolutePath(), false, true, false)
+
+        // a test spec that matches every method by name and has no return-type restriction -
+        // without the fix this also matches constructors
+        TestSpec spec = new TestSpec()
+        spec.setMethodPattern(Pattern.compile(".*"))
+        config.setTestDetector(spec)
+
+        String instr = getInstrumentedVersion(
+                "public class MyTest { static class Inner { Inner(String value){ super(); } } }", config)
+
+        // the constructor keeps its explicit super() call in place (not moved into a helper)
+        assertTrue("super() must be preserved in the constructor body", instr.contains("super();"))
+        // and no per-test rewrite scaffold (Throwable capture) is emitted for the constructor
+        assertFalse("constructor must not be rewritten as a test method", instr.contains("java.lang.Throwable"))
     }
 }

--- a/clover-core/src/test/groovy/org/openclover/core/instr/tests/TestSpecTest.groovy
+++ b/clover-core/src/test/groovy/org/openclover/core/instr/tests/TestSpecTest.groovy
@@ -146,4 +146,18 @@ class TestSpecTest {
         assertTrue(spec.isMethodMatch(null, JavaMethodContext.createFor(sig)))
     }
 
+    @Test
+    void testIsMethodMatchExcludesConstructors() {
+        // permissive method pattern, no return-type pattern - matches any method name
+        spec.setMethodPattern(Pattern.compile(".*"))
+
+        // a regular method still matches
+        MethodSignature method = new MethodSignature(null, null, null, null, mods, "MyInnerClass", null, "void", null, null)
+        assertTrue(spec.isMethodMatch(null, JavaMethodContext.createFor(method)))
+
+        // but a constructor (null return type) must not match - see OC-249
+        MethodSignature ctor = new MethodSignature(null, null, null, null, mods, "MyInnerClass", null, null, null, null)
+        assertFalse(spec.isMethodMatch(null, JavaMethodContext.createFor(ctor)))
+    }
+
 }


### PR DESCRIPTION
Don't rewrite constructors like it's done for test methods in test classes.

Test methods normally get wrapped into try-catch and a new method is added. But this breaks "super()" calls in constructors.